### PR TITLE
feat(sprint-67): S67-06 — /site landing page + CNAME for GitHub Pages

### DIFF
--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+sdlcframework.org

--- a/site/app-sdlc.jsx
+++ b/site/app-sdlc.jsx
@@ -1,0 +1,84 @@
+/* global React, ReactDOM,
+   SdlcNav, SdlcHero, PromiseSection, PillarsSection, StagesSection,
+   TiersSection, GatesSection, VibeSection, SoulsSection, TrainingSection,
+   RefsSection, AdoptSection, StandardsSection, FaqSdlc, FootSdlc,
+   TweaksPanel, useTweaks, TweakSection, TweakRadio, TweakToggle */
+
+const TWEAK_DEFAULTS_SDLC = /*EDITMODE-BEGIN*/{
+  "theme": "rust",
+  "density": "cozy",
+  "showVibe": true,
+  "showStandards": true,
+  "showTraining": true
+}/*EDITMODE-END*/;
+
+function AppSdlc() {
+  const [lang, setLang] = React.useState(() => localStorage.getItem("sdlc-lang") || "en");
+  React.useEffect(() => {
+    localStorage.setItem("sdlc-lang", lang);
+    document.documentElement.lang = lang;
+  }, [lang]);
+
+  const [tweaks, setTweak] = useTweaks(TWEAK_DEFAULTS_SDLC);
+
+  React.useEffect(() => {
+    document.documentElement.dataset.theme = tweaks.theme;
+    document.documentElement.dataset.density = tweaks.density;
+    document.documentElement.dataset.site = "sdlc";
+  }, [tweaks.theme, tweaks.density]);
+
+  const t = window.sdlcCopy[lang];
+
+  return (
+    <>
+      <SdlcNav t={t} lang={lang} setLang={setLang} />
+      <SdlcHero t={t} />
+      <PromiseSection t={t} />
+      <PillarsSection t={t} />
+      <StagesSection t={t} />
+      <TiersSection t={t} />
+      <GatesSection t={t} />
+      {tweaks.showVibe && <VibeSection t={t} />}
+      <SoulsSection t={t} />
+      {tweaks.showTraining && <TrainingSection t={t} />}
+      <RefsSection t={t} />
+      <AdoptSection t={t} />
+      {tweaks.showStandards && <StandardsSection t={t} />}
+      <FaqSdlc t={t} />
+      <FootSdlc t={t} />
+
+      <TweaksPanel title="Tweaks">
+        <TweakSection label="Theme">
+          <TweakRadio
+            label="Palette"
+            value={tweaks.theme}
+            onChange={(v) => setTweak("theme", v)}
+            options={[
+              { value: "rust", label: "Rust" },
+              { value: "ink", label: "Ink" },
+              { value: "cobalt", label: "Cobalt" },
+              { value: "paper", label: "Paper" },
+            ]}
+          />
+          <TweakRadio
+            label="Density"
+            value={tweaks.density}
+            onChange={(v) => setTweak("density", v)}
+            options={[
+              { value: "cozy", label: "Cozy" },
+              { value: "compact", label: "Compact" },
+            ]}
+          />
+        </TweakSection>
+        <TweakSection label="Sections">
+          <TweakToggle label="Vibecoding meter" value={tweaks.showVibe} onChange={(v) => setTweak("showVibe", v)} />
+          <TweakToggle label="Training modules" value={tweaks.showTraining} onChange={(v) => setTweak("showTraining", v)} />
+          <TweakToggle label="Standards alignment" value={tweaks.showStandards} onChange={(v) => setTweak("showStandards", v)} />
+        </TweakSection>
+      </TweaksPanel>
+    </>
+  );
+}
+
+const rootSdlc = ReactDOM.createRoot(document.getElementById("root"));
+rootSdlc.render(<AppSdlc />);

--- a/site/components-base.jsx
+++ b/site/components-base.jsx
@@ -1,0 +1,175 @@
+/* global React */
+/* ============================================================
+   Endiorbot — shared UI components (icons, brand, terminal)
+   ============================================================ */
+const { useState, useEffect, useRef, useMemo } = React;
+
+/* ---------- Brandmark ---------- */
+function Brandmark({ size = 28 }) {
+  return (
+    <span className="brandmark">
+      <span className="brand-glyph" style={{ width: size, height: size }}>
+        <svg viewBox="0 0 32 32" width={size} height={size} aria-hidden="true">
+          <defs>
+            <linearGradient id="ebg" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stopColor="var(--accent-2)" />
+              <stop offset="100%" stopColor="var(--accent)" />
+            </linearGradient>
+          </defs>
+          {/* outer orbit */}
+          <ellipse cx="16" cy="16" rx="14" ry="6" fill="none" stroke="var(--ink-3)" strokeWidth="1" opacity="0.55" transform="rotate(-22 16 16)" />
+          {/* inner E */}
+          <path d="M9 9 H22 M9 16 H19 M9 23 H22" stroke="url(#ebg)" strokeWidth="2.4" strokeLinecap="round" fill="none" />
+          {/* satellite dot */}
+          <circle cx="27.4" cy="11.4" r="2.1" fill="url(#ebg)" />
+        </svg>
+      </span>
+      <span className="brand-name">Endior<span className="dot-orbit">·</span>bot</span>
+    </span>
+  );
+}
+
+/* ---------- Channel icons (small, line) ---------- */
+const Icon = {
+  CLI: () => (
+    <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="2.5" y="4.5" width="19" height="15" rx="2" /><path d="M6 9.5l3 2.5-3 2.5M11 15h6" />
+    </svg>
+  ),
+  Web: () => (
+    <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="9" /><path d="M3 12h18M12 3c2.5 3 2.5 15 0 18M12 3c-2.5 3-2.5 15 0 18" />
+    </svg>
+  ),
+  Telegram: () => (
+    <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 4 3 11l6 2 2 6 4-5 5 4 1-14z" /><path d="M9 13l9-7" />
+    </svg>
+  ),
+  Zalo: () => (
+    <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 6h16v10H8l-4 4V6z" /><path d="M8 11h2l-2 2h2M14 11l2 2 2-2M14 13v-2" />
+    </svg>
+  ),
+  Desktop: () => (
+    <svg viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="2.5" y="4" width="19" height="13" rx="1.5" /><path d="M9 21h6M12 17v4" />
+    </svg>
+  ),
+  Github: () => (
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M12 .3a12 12 0 0 0-3.79 23.4c.6.1.82-.26.82-.58v-2c-3.34.72-4.04-1.6-4.04-1.6-.55-1.39-1.34-1.76-1.34-1.76-1.09-.74.08-.73.08-.73 1.21.09 1.84 1.24 1.84 1.24 1.07 1.83 2.81 1.3 3.5 1 .1-.78.42-1.3.76-1.6-2.66-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.11-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.65 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.81 5.62-5.49 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 12 .3"/></svg>
+  ),
+  Star: () => (
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M12 2l3.1 6.3 6.9 1-5 4.9 1.2 6.9L12 18l-6.2 3.1L7 14.2 2 9.3l6.9-1z"/></svg>
+  ),
+  Arrow: () => (
+    <svg className="arr" viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M3 8h10M9 4l4 4-4 4" /></svg>
+  ),
+};
+
+/* ---------- Animated terminal ---------- */
+function Terminal({ data, key }) {
+  const [step, setStep] = useState(0);
+  const [typed, setTyped] = useState("");
+  const [phase, setPhase] = useState("typing"); // typing | output | wait
+  const dataRef = useRef(data);
+  useEffect(() => { dataRef.current = data; setStep(0); setTyped(""); setPhase("typing"); }, [data]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer;
+    const lines = dataRef.current.lines;
+    if (step >= lines.length) {
+      // restart loop after pause
+      timer = setTimeout(() => {
+        if (!cancelled) { setStep(0); setTyped(""); setPhase("typing"); }
+      }, 4000);
+      return () => { cancelled = true; clearTimeout(timer); };
+    }
+    const line = lines[step];
+    if (line.t === "prompt") {
+      // type the cmd char by char
+      const cmd = line.c || "";
+      if (typed.length < cmd.length) {
+        timer = setTimeout(() => setTyped(cmd.slice(0, typed.length + 1)), 28 + Math.random() * 30);
+      } else {
+        timer = setTimeout(() => { setStep(s => s + 1); setTyped(""); }, 480);
+      }
+    } else if (line.t === "spacer") {
+      timer = setTimeout(() => setStep(s => s + 1), 80);
+    } else {
+      // output / comment / caret
+      timer = setTimeout(() => setStep(s => s + 1), line.t === "caret" ? 1500 : 380);
+    }
+    return () => { cancelled = true; clearTimeout(timer); };
+  }, [step, typed]);
+
+  const lines = data.lines;
+  return (
+    <div className="terminal" role="img" aria-label="endiorbot terminal demo">
+      <div className="terminal-bar">
+        <div className="dots"><span /><span /><span /></div>
+        <div className="title">{data.title}</div>
+        <div style={{ width: 48 }} />
+      </div>
+      <div className="terminal-body">
+        {lines.slice(0, step + 1).map((ln, i) => {
+          const isCurrent = i === step;
+          if (ln.t === "spacer") return <div key={i} className="line">&nbsp;</div>;
+          if (ln.t === "caret") return <div key={i} className="line"><span className="prompt">$</span> <span className="caret" /></div>;
+          if (ln.t === "comment") return <div key={i} className="line"><span className="comment">{ln.v}</span></div>;
+          if (ln.t === "prompt") {
+            const full = ln.c || "";
+            const text = isCurrent ? typed : full;
+            return (
+              <div key={i} className="line">
+                <span className="prompt">{ln.v}</span>{" "}
+                <span dangerouslySetInnerHTML={{ __html: highlightCmd(text) }} />
+                {isCurrent && typed.length < full.length && <span className="caret" />}
+              </div>
+            );
+          }
+          if (ln.t === "out") {
+            return <div key={i} className="line"><span className="ok" dangerouslySetInnerHTML={{ __html: highlightOut(ln.v) }} /></div>;
+          }
+          return null;
+        })}
+      </div>
+    </div>
+  );
+}
+
+function highlightCmd(s) {
+  // basic highlight: @agent, --flag, "strings"
+  return escapeHtml(s)
+    .replace(/(@[a-z]+)/g, '<span class="at-agent">$1</span>')
+    .replace(/(--?[a-z][\w-]*)/g, '<span class="keyw">$1</span>');
+}
+function highlightOut(s) {
+  return escapeHtml(s)
+    .replace(/(@[a-z]+)/g, '<span class="at-agent">$1</span>');
+}
+function escapeHtml(s) { return s.replace(/[&<>]/g, m => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[m])); }
+
+/* ---------- Install bar ---------- */
+function InstallBar({ cmd }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(cmd);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    } catch {}
+  };
+  return (
+    <div className="install" role="group" aria-label="install command">
+      <span className="prompt">$</span>
+      <span className="cmd">{cmd}</span>
+      <button className={"copy" + (copied ? " copied" : "")} onClick={onCopy} aria-label="copy install command">
+        {copied ? "COPIED" : "COPY"}
+      </button>
+    </div>
+  );
+}
+
+Object.assign(window, { Brandmark, Icon, Terminal, InstallBar });

--- a/site/components-sdlc.jsx
+++ b/site/components-sdlc.jsx
@@ -1,0 +1,529 @@
+/* global React, Brandmark, Icon */
+/* ============================================================
+   SDLC Framework — landing components
+   ============================================================ */
+const { useState: useStateS, useEffect: useEffectS } = React;
+
+/* ---------- SDLC brand mark (different from Endiorbot) ---------- */
+function SdlcBrand({ size = 28 }) {
+  return (
+    <span className="brandmark">
+      <span className="brand-glyph" style={{ width: size, height: size }}>
+        <svg viewBox="0 0 32 32" width={size} height={size} aria-hidden="true">
+          <defs>
+            <linearGradient id="sbg" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stopColor="var(--accent-2)" />
+              <stop offset="100%" stopColor="var(--accent)" />
+            </linearGradient>
+          </defs>
+          {[0,1,2,3,4,5,6].map(i => {
+            const a = (i / 7) * Math.PI * 2 - Math.PI / 2;
+            const r = 10;
+            const cx = 16 + Math.cos(a) * r;
+            const cy = 16 + Math.sin(a) * r;
+            return <circle key={i} cx={cx} cy={cy} r="2.2" fill="url(#sbg)" />;
+          })}
+          <circle cx="16" cy="16" r="2.6" fill="none" stroke="var(--ink)" strokeWidth="1.2" />
+        </svg>
+      </span>
+      <span className="brand-name">SDLC<span className="dot-orbit"> · </span>Framework</span>
+    </span>
+  );
+}
+
+/* ---------- Top nav ---------- */
+function SdlcNav({ t, lang, setLang }) {
+  return (
+    <nav className="nav">
+      <div className="shell nav-inner">
+        <a href="#top" aria-label="SDLC Framework"><SdlcBrand /></a>
+        <div className="nav-links">
+          <a href="#pillars">{t.nav.framework}</a>
+          <a href="#stages">Stages</a>
+          <a href="#tiers">Tiers</a>
+          <a href="#souls">Roles</a>
+          <a href="#refs">{t.nav.endiorbot}</a>
+          <a href="#adopt">Adopt</a>
+        </div>
+        <div className="nav-actions">
+          <div className="lang" role="group" aria-label="language">
+            <button aria-pressed={lang === "en"} onClick={() => setLang("en")}>EN</button>
+            <button aria-pressed={lang === "vi"} onClick={() => setLang("vi")}>VI</button>
+          </div>
+          <a href="#" className="btn btn-ghost" style={{ padding: "8px 14px" }}>
+            <Icon.Github />
+            <span style={{ fontSize: 12, fontFamily: "var(--font-mono)" }}>sdlc/framework</span>
+          </a>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+/* ---------- Hero ---------- */
+function SdlcHero({ t }) {
+  const stats = [t.hero.stat1, t.hero.stat2, t.hero.stat3, t.hero.stat4, t.hero.stat5];
+  return (
+    <section className="hero" id="top">
+      <div className="shell">
+        <div className="hero-meta">
+          <span className="pill"><span className="live" />{t.hero.eyebrow}</span>
+        </div>
+        <h1 className="display" style={{ marginBottom: 28, maxWidth: "16ch" }}>
+          {t.hero.headline_a}{" "}<em>{t.hero.headline_em}</em>{" "}{t.hero.headline_b}
+        </h1>
+        <p className="hero-sub" style={{ maxWidth: "62ch" }}>{t.hero.sub}</p>
+        <div className="hero-cta">
+          <a href="#pillars" className="btn btn-primary">{t.hero.ctaPrimary}<Icon.Arrow /></a>
+          <a href="#refs" className="btn btn-ghost">{t.hero.ctaSecondary}</a>
+        </div>
+        <div className="hero-strip" role="list">
+          {stats.map((s, i) => (
+            <div key={i} role="listitem">
+              <div className="num">{i === 0 ? <span className="accent">{s.n}</span> : s.n}</div>
+              <div className="lbl">{s.l}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- Promise ---------- */
+function PromiseSection({ t }) {
+  return (
+    <section className="section-divider" id="promise">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{t.promise.eyebrow}</div>
+          <h2 className="section-h">{t.promise.title}</h2>
+        </div>
+        <p style={{ fontSize: "clamp(18px, 1.7vw, 24px)", color: "var(--ink-2)", maxWidth: "70ch", lineHeight: 1.55, textWrap: "pretty" }}>
+          {t.promise.body}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- Seven pillars ---------- */
+function PillarsSection({ t }) {
+  return (
+    <section className="section-divider" id="pillars">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{t.pillars.eyebrow}</div>
+          <h2 className="section-h">{t.pillars.title}</h2>
+          <p className="lede">{t.pillars.sub}</p>
+        </div>
+        <div className="pillars-grid">
+          {t.pillars.items.map((p, i) => (
+            <div className="pillar-card" key={i}>
+              <div className="num">{p.n}</div>
+              <h4>{p.t}</h4>
+              <p>{p.d}</p>
+            </div>
+          ))}
+          <div className="pillar-card p7">
+            <div className="num">{t.pillars.sec7.n}</div>
+            <h4>{t.pillars.sec7.t}</h4>
+            <p>{t.pillars.sec7.d}</p>
+          </div>
+          <div className="pillar-card p7" style={{ gridColumn: "span 2" }}>
+            <div className="num">{t.pillars.sec8.n}</div>
+            <h4>{t.pillars.sec8.t}</h4>
+            <p>{t.pillars.sec8.d}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- 10-Stage timeline (interactive) ---------- */
+function StagesSection({ t }) {
+  const [sel, setSel] = useStateS(0);
+  const stage = t.stages.data[sel];
+  return (
+    <section className="section-divider" id="stages">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{t.stages.eyebrow}</div>
+          <h2 className="section-h">{t.stages.title}</h2>
+          <p className="lede">{t.stages.sub}</p>
+        </div>
+        <div className="stages-timeline" role="tablist">
+          {t.stages.data.map((s, i) => (
+            <div key={i} className="stage-cell"
+                 role="tab" tabIndex={0}
+                 aria-selected={i === sel}
+                 onClick={() => setSel(i)}
+                 onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setSel(i); }}>
+              <div className="sid">{s.id}</div>
+              <div className="sname">{s.name}</div>
+              <div className="sgate">{s.q}</div>
+            </div>
+          ))}
+        </div>
+        <div className="stage-detail">
+          <div>
+            <h3 style={{ marginBottom: 14 }}>{stage.id} · {stage.name}</h3>
+            <div className="meta">
+              <span><strong>Gate:</strong> {stage.gate}</span>
+              <span><strong>Reqs:</strong> {stage.reqs}</span>
+              <span><strong>Parallel:</strong> {stage.parallel}</span>
+            </div>
+          </div>
+          <ul>
+            {stage.deliverables.map((d, i) => (
+              <li key={i}><span className="k">{d[0]}</span><span>{d[1]}</span></li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- Four tiers ---------- */
+function TiersSection({ t }) {
+  return (
+    <section className="section-divider" id="tiers">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{t.tiers.eyebrow}</div>
+          <h2 className="section-h">{t.tiers.title}</h2>
+          <p className="lede">{t.tiers.sub}</p>
+        </div>
+        <div className="tiers-grid">
+          {t.tiers.items.map((tier, i) => (
+            <div className="tier-card" key={i} data-rec={tier.rec}>
+              <div className="lvl">{tier.lvl}</div>
+              <h4>{tier.name}</h4>
+              <div className="who">{tier.who}</div>
+              <div className="num"><em>Stages:</em> {tier.stages}</div>
+              <ul>
+                {tier.features.map((f, j) => <li key={j}>{f}</li>)}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- Quality gates ---------- */
+function GatesSection({ t }) {
+  return (
+    <section className="section-divider" id="gates">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{t.gates.eyebrow}</div>
+          <h2 className="section-h">{t.gates.title}</h2>
+          <p className="lede">{t.gates.sub}</p>
+        </div>
+        <div className="gates" style={{ padding: 0 }}>
+          {t.gates.items.map((g, i) => (
+            <div key={i} style={{
+              display: "grid",
+              gridTemplateColumns: "80px 1fr 1.6fr",
+              gap: 24, alignItems: "center",
+              padding: "22px 28px",
+              borderTop: i === 0 ? 0 : "1px solid var(--line)"
+            }}>
+              <div style={{
+                fontFamily: "var(--font-display)",
+                fontSize: 36, color: "var(--accent)", letterSpacing: "-0.02em"
+              }}>{g.id}</div>
+              <div>
+                <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, letterSpacing: "0.08em", color: "var(--ink-3)", textTransform: "uppercase" }}>{g.phase}</div>
+                <div style={{ fontFamily: "var(--font-display)", fontSize: 22, color: "var(--ink)", letterSpacing: "-0.02em", marginTop: 4 }}>{g.title}</div>
+              </div>
+              <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 6 }}>
+                {g.ev.map((e, j) => (
+                  <li key={j} style={{ fontSize: 13.5, color: "var(--ink-2)", display: "flex", gap: 10 }}>
+                    <span style={{ color: "var(--accent)", fontFamily: "var(--font-mono)" }}>✓</span>{e}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- Vibecoding meter ---------- */
+function VibeSection({ t }) {
+  return (
+    <section className="section-divider" id="vibe">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{t.vibe.eyebrow}</div>
+          <h2 className="section-h">{t.vibe.title}</h2>
+          <p className="lede">{t.vibe.body}</p>
+        </div>
+        <div className="vibe-wrap">
+          <div className="vibe-meter">
+            <h4>Signal weights</h4>
+            {t.vibe.signals.map((s, i) => (
+              <div key={i} className="row"><span>{s.l}</span><span>{s.w}</span></div>
+            ))}
+          </div>
+          <div className="vibe-meter">
+            <h4>Routing</h4>
+            <div className="scale" style={{ marginTop: 14 }}>
+              <i className="a" /><i className="b" /><i className="c" /><i className="d" />
+            </div>
+            <div className="ticks">
+              <span>0</span><span>20</span><span>40</span><span>60</span><span>100</span>
+            </div>
+            <div style={{ marginTop: 18 }}>
+              {t.vibe.routing.map((r, i) => (
+                <div key={i} className="row">
+                  <span><strong style={{ color: "var(--ink)", marginRight: 10 }}>{r.range}</strong>{r.label}</span>
+                  <span>{r.action}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- 18 SOULs ---------- */
+function SoulsSection({ t }) {
+  return (
+    <section className="section-divider" id="souls">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{t.souls.eyebrow}</div>
+          <h2 className="section-h">{t.souls.title}</h2>
+          <p className="lede">{t.souls.sub}</p>
+        </div>
+        <div className="agents-legend" style={{ marginBottom: 20 }}>
+          {t.souls.tiers.map((tier, i) => (
+            <span key={i}>
+              <i style={{
+                background: tier.c === "advisor" ? "var(--violet)" :
+                           tier.c === "executor" ? "var(--accent)" : "var(--ink-3)"
+              }} />{tier.l}
+            </span>
+          ))}
+        </div>
+        <div className="souls-grid">
+          {t.souls.items.map((s, i) => (
+            <div key={i} className={`soul-cell ${s.c}`}>
+              <div className="role">{s.role}</div>
+              <div className="name">@{s.name}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- Training modules ---------- */
+function TrainingSection({ t }) {
+  return (
+    <section className="section-divider" id="training">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{t.training.eyebrow}</div>
+          <h2 className="section-h">{t.training.title}</h2>
+          <p className="lede">{t.training.sub}</p>
+        </div>
+        <div className="modules-list">
+          {t.training.items.map((m, i) => (
+            <div className="module-row" key={i}>
+              <div className="midx">M{m.i}</div>
+              <div className="mtitle">{m.t}<small>{m.sub}</small></div>
+              <div className="mhrs">{m.h}</div>
+              <div className="mtier">{m.tier}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- Reference implementations ---------- */
+function RefsSection({ t }) {
+  const r = t.refs;
+  return (
+    <section className="section-divider" id="refs">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{r.eyebrow}</div>
+          <h2 className="section-h">{r.title}</h2>
+          <p className="lede">{r.sub}</p>
+        </div>
+        <div className="refs-grid">
+          <div className="ref-card live">
+            <div className="badge"><span className="live" />{r.endior.badge}</div>
+            <h3>{r.endior.title}</h3>
+            <p>{r.endior.body}</p>
+            <div className="ctas">
+              {r.endior.ctas.map((c, i) => (
+                <a key={i} href={c[1]} className={i === 0 ? "btn btn-primary" : "btn btn-ghost"}>{c[0]}</a>
+              ))}
+            </div>
+            <div className="stats">
+              {r.endior.stats.map((s, i) => (
+                <div key={i}><div className="num">{s[0]}</div><div className="lbl">{s[1]}</div></div>
+              ))}
+            </div>
+          </div>
+          <div className="ref-card">
+            <div className="badge">{r.orch.badge}</div>
+            <h3>{r.orch.title}</h3>
+            <p>{r.orch.body}</p>
+            <div className="ctas">
+              {r.orch.ctas.map((c, i) => (
+                <a key={i} href={c[1]} className={i === 0 ? "btn btn-primary" : "btn btn-ghost"}>{c[0]}</a>
+              ))}
+            </div>
+            <div className="stats">
+              {r.orch.stats.map((s, i) => (
+                <div key={i}><div className="num">{s[0]}</div><div className="lbl">{s[1]}</div></div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- Adoption rail ---------- */
+function AdoptSection({ t }) {
+  return (
+    <section className="section-divider" id="adopt">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{t.adopt.eyebrow}</div>
+          <h2 className="section-h">{t.adopt.title}</h2>
+          <p className="lede">{t.adopt.sub}</p>
+        </div>
+        <div className="adopt-rail">
+          {t.adopt.steps.map((s, i) => (
+            <div className="adopt-step" key={i}>
+              <div className="day">{s.day}</div>
+              <div className="num">{s.num}</div>
+              <h4>{s.t}</h4>
+              <p>{s.d}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- Standards ---------- */
+function StandardsSection({ t }) {
+  return (
+    <section className="section-divider" id="standards">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{t.standards.eyebrow}</div>
+          <h2 className="section-h">{t.standards.title}</h2>
+          <p className="lede">{t.standards.sub}</p>
+        </div>
+        <div style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4, 1fr)",
+          gap: 12,
+        }}>
+          {t.standards.items.map((it, i) => (
+            <div key={i} style={{
+              background: "var(--bg-1)",
+              border: "1px solid var(--line)",
+              borderRadius: 12,
+              padding: "20px 22px",
+              minHeight: 110,
+              display: "flex", flexDirection: "column", gap: 6
+            }}>
+              <div style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 12,
+                color: "var(--accent)",
+                letterSpacing: "0.04em"
+              }}>{it[0]}</div>
+              <div style={{ fontSize: 13, color: "var(--ink-2)", lineHeight: 1.5 }}>{it[1]}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- FAQ ---------- */
+function FaqSdlc({ t }) {
+  const [open, setOpen] = useStateS(0);
+  return (
+    <section className="section-divider" id="faq">
+      <div className="shell">
+        <div className="section-head">
+          <div className="eyebrow"><span className="dot" />{t.faq.eyebrow}</div>
+          <h2 className="section-h">{t.faq.title}</h2>
+        </div>
+        <div className="faq-wrap">
+          {t.faq.items.map((it, i) => (
+            <div key={i} className="faq-item" data-open={i === open}>
+              <button className="faq-q" onClick={() => setOpen(i === open ? -1 : i)}>
+                <span>{it.q}</span><span className="marker">+</span>
+              </button>
+              <div className="faq-a"><p style={{ margin: 0 }}>{it.a}</p></div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- Footer ---------- */
+function FootSdlc({ t }) {
+  return (
+    <footer className="foot">
+      <div className="shell">
+        <div className="foot-grid">
+          <div>
+            <SdlcBrand />
+            <p className="foot-tag" style={{ marginTop: 14 }}>
+              <strong style={{ color: "var(--ink-2)" }}>{t.footer.tag}</strong><br />
+              {t.footer.sub}
+            </p>
+          </div>
+          {t.footer.cols.map((c, i) => (
+            <div className="foot-col" key={i}>
+              <h5>{c.t}</h5>
+              <ul>
+                {c.links.map((l, j) => <li key={j}><a href={l[1]}>{l[0]}</a></li>)}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className="foot-bottom">
+          <span>{t.footer.auth}</span>
+          <span>v6.3.1 · MIT</span>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+Object.assign(window, {
+  SdlcBrand, SdlcNav, SdlcHero, PromiseSection, PillarsSection, StagesSection,
+  TiersSection, GatesSection, VibeSection, SoulsSection, TrainingSection,
+  RefsSection, AdoptSection, StandardsSection, FaqSdlc, FootSdlc
+});

--- a/site/copy-sdlc.js
+++ b/site/copy-sdlc.js
@@ -1,0 +1,608 @@
+/* ============================================================
+   SDLC Framework — copy strings (EN/VI bilingual)
+   ============================================================ */
+const sdlcCopy = {
+  en: {
+    nav: { framework: "Framework", endiorbot: "Endiorbot", orchestrator: "Orchestrator", lang: "EN" },
+    hero: {
+      eyebrow: "v6.3.1 · April 2026 · MIT Licensed",
+      headline_a: "A 7-pillar methodology for",
+      headline_em: "AI + Human teams",
+      headline_b: "that actually ship.",
+      sub: "Tool-agnostic. Battle-tested in production. 503 documents, 39h of training, 18 SOUL roles, 10 stages, 5 quality gates — all open source.",
+      ctaPrimary: "Read the Executive Summary",
+      ctaSecondary: "See live reference: Endiorbot →",
+      stat1: { n: "11", l: "training modules" },
+      stat2: { n: "39h", l: "curriculum" },
+      stat3: { n: "18", l: "SOUL roles" },
+      stat4: { n: "10", l: "lifecycle stages" },
+      stat5: { n: "503+", l: "framework docs" },
+    },
+    promise: {
+      eyebrow: "The promise",
+      title: "Built BY AI+Human teams. FOR AI+Human teams.",
+      body: "Most SDLC frameworks were written before LLMs existed. They treat AI as a tool you bolt on. SDLC 6.3.1 starts from a different premise: humans guide, agents execute, humans verify — at every stage, with evidence, with gates, with accountability. The framework is what's left when you remove every assumption that AI doesn't exist.",
+    },
+    pillars: {
+      eyebrow: "Pillar 0 → 6 + Section 7 + 8",
+      title: "Seven pillars, two extensions.",
+      sub: "Every pillar is independent. Adopt one or all seven — the framework scales from solo developer to enterprise.",
+      items: [
+        { n: "P0", t: "Design Thinking", d: "Empathize → Define → Ideate → Prototype → Test. Validate problems before building solutions. Cuts the 70% feature-waste rate the industry quietly lives with." },
+        { n: "P1", t: "10-Stage Lifecycle", d: "Foundation → Govern. Every stage has explicit prerequisites, exit criteria, and tier-aware requirements. Skip with eyes open, not by accident." },
+        { n: "P2", t: "Sprint Governance", d: "Three-phase sprint model with TDD baked in. G-Sprint and G-Sprint-Close gates. 24-hour documentation rule. Ten golden rules for sprint integrity." },
+        { n: "P3", t: "4-Tier Classification", d: "LITE (1-2 devs) → STANDARD → PROFESSIONAL → ENTERPRISE (50+). Tier dictates required stages, documentation depth, and tooling — not the other way around." },
+        { n: "P4", t: "Quality Gates", d: "Dual-track gates: feature (G0–G4) and sprint (G-Sprint). Evidence-based passes. No green-light without artifacts. Vibecoding Index quantifies risk." },
+        { n: "P5", t: "SASE Integration", d: "Software Agent Software Engineering 3.0. SE4H (humans coach) vs SE4A (agents execute). AGENTS.md + CRP + MRP + VCR. 13 roles in the canonical model." },
+        { n: "P6", t: "Documentation Permanence", d: "AI-parseable formats. YAML frontmatter mandatory. BDD requirements (GIVEN-WHEN-THEN). Specs are the single source of truth — not Slack threads." },
+      ],
+      sec7: { n: "§7", t: "Quality Assurance System", d: "Anti-Vibecoding controls. Vibecoding Index (0–100). Progressive routing: green auto-merge → red CTO override. Auto-generation reduces compliance friction from 30 min to <5 min per PR." },
+      sec8: { n: "§8", t: "Unified Specification Standard", d: "Mandatory YAML frontmatter, BDD requirements, lightweight ADRs (DESIGN_DECISIONS), version tracking (SPEC_DELTA). Format-agnostic SpecIR converts OpenSpec ↔ SDLC bidirectionally." },
+    },
+    stages: {
+      eyebrow: "Pillar 1",
+      title: "Ten stages. Two questions per stage.",
+      sub: "Click any stage to inspect prerequisites, exit gate, and key deliverables.",
+      data: [
+        { id: "00", name: "Foundation", q: "WHY?", gate: "G0.1 / G0.2", reqs: "—", parallel: "No",
+          deliverables: [
+            ["Question", "Why are we building this?"],
+            ["Output", "Business case · Problem statement · 3 evidence-based personas"],
+            ["Gate", "G0.1 (problem validated, 5+ users) → G0.2 (solution diversity, 100+ ideas)"],
+            ["Skip risk", "Critical — skipping causes 70% feature waste"],
+          ]
+        },
+        { id: "01", name: "Planning", q: "WHAT?", gate: "G1", reqs: "00 + G0.2", parallel: "No",
+          deliverables: [
+            ["Question", "What are we building?"],
+            ["Output", "Requirements · User stories · API specs · Acceptance criteria"],
+            ["Format", "BDD (GIVEN-WHEN-THEN) mandatory at STANDARD+"],
+            ["Gate", "G1 — stakeholders approve, requirements complete"],
+          ]
+        },
+        { id: "02", name: "Design", q: "HOW?", gate: "G2", reqs: "01 + G1", parallel: "No",
+          deliverables: [
+            ["Question", "How will we build it?"],
+            ["Output", "Architecture · ADRs · Threat model · Security design"],
+            ["Templates", "ADR-NNN, SPEC-NNNN with YAML frontmatter"],
+            ["Gate", "G2 — CTO/Tech Lead approval"],
+          ]
+        },
+        { id: "03", name: "Integrate", q: "Connect?", gate: "G2", reqs: "02 + G2", parallel: "Yes (with 04)",
+          deliverables: [
+            ["Question", "How does it connect to the world?"],
+            ["Output", "API contracts · Integration tests · OpenAPI SSOT"],
+            ["Cross-ref", "Stage 03 ↔ Stage 05 traceability matrix"],
+            ["Pattern", "Parallel with Build via API-first development"],
+          ]
+        },
+        { id: "04", name: "Build", q: "Right?", gate: "G3", reqs: "02 + G2", parallel: "Yes (with 03)",
+          deliverables: [
+            ["Question", "Are we building it right?"],
+            ["Output", "Working code · Unit tests · Coverage at tier target"],
+            ["TDD", "RED → GREEN → REFACTOR per feature"],
+            ["Coverage", "LITE 70% · STD 85% · PRO/ENT 95%"],
+          ]
+        },
+        { id: "05", name: "Test", q: "Works?", gate: "G3", reqs: "04 + G3", parallel: "No",
+          deliverables: [
+            ["Question", "Does it work correctly?"],
+            ["Output", "Test reports · UAT sign-off · OWASP API Top-10 checked"],
+            ["Workflow", "6-phase E2E: Discovery → Config → Execution → Security → Reporting → Integration"],
+            ["Saves", "~83% setup time vs ad-hoc testing"],
+          ]
+        },
+        { id: "06", name: "Deploy", q: "Ship?", gate: "G4", reqs: "05 + G3", parallel: "No",
+          deliverables: [
+            ["Question", "How do we ship safely?"],
+            ["Output", "Release notes · Rollback procedures · Deployment evidence"],
+            ["Checklist", "100-item Go-Live Readiness (tier-aware)"],
+            ["Gate", "G4 — production stability confirmed"],
+          ]
+        },
+        { id: "07", name: "Operate", q: "Running?", gate: "Continuous", reqs: "06 + G4", parallel: "Yes",
+          deliverables: [
+            ["Question", "Is it running reliably?"],
+            ["Output", "Runbooks · Monitoring dashboards · SLO definitions"],
+            ["Metrics", "DORA: deployment frequency, lead time, MTTR, CFR"],
+            ["Target", "99.9%+ uptime at PRO/ENT tier"],
+          ]
+        },
+        { id: "08", name: "Collaborate", q: "Effective?", gate: "Continuous", reqs: "01+", parallel: "Yes",
+          deliverables: [
+            ["Question", "Is the team effective?"],
+            ["Output", "Team charter · AGENTS.md · Training materials"],
+            ["Roles", "13-role SASE model + 10 TEAM charters"],
+            ["Pattern", "Runs throughout — never blocks delivery"],
+          ]
+        },
+        { id: "09", name: "Govern", q: "Compliant?", gate: "Continuous", reqs: "06 + G4", parallel: "Yes",
+          deliverables: [
+            ["Question", "Are we compliant?"],
+            ["Output", "Compliance reports · Audit logs · Risk register"],
+            ["Standards", "SOC 2 · HIPAA · GDPR · NIST SSDF mappings"],
+            ["Early start", "Can begin at Stage 01 if regulated industry"],
+          ]
+        },
+      ]
+    },
+    tiers: {
+      eyebrow: "Pillar 3",
+      title: "One framework. Four tiers.",
+      sub: "Pick the tier that fits your team — don't pick a tier above it. The framework scales down as gracefully as it scales up.",
+      items: [
+        { lvl: "T1", name: "LITE", who: "1–2 developers · Solo · Indie", stages: "00, 01, 02, 04",
+          features: ["3 SOUL roles", "README + .env.example", "70% test coverage", "AGENTS.md <60 lines"], rec: false },
+        { lvl: "T2", name: "STANDARD", who: "3–10 developers · Startups · Small agencies", stages: "00–02, 04–06",
+          features: ["6 SOUL roles", "+ CLAUDE.md + /docs", "85% test coverage", "BDD requirements"], rec: true },
+        { lvl: "T3", name: "PROFESSIONAL", who: "10–50 developers · Growth-stage", stages: "All 10 stages",
+          features: ["11 SOUL roles", "+ Full ADRs + Compliance", "95% test coverage", "Senior review board"], rec: false },
+        { lvl: "T4", name: "ENTERPRISE", who: "50+ developers · Regulated · Public", stages: "All 10 stages",
+          features: ["14 SOUL roles", "+ Executive reports + Audit", "95%+ with security tests", "All sections active"], rec: false },
+      ]
+    },
+    gates: {
+      eyebrow: "Pillar 4",
+      title: "Five gates. Evidence or no pass.",
+      sub: "Quality gates are not approvals — they are evidence checkpoints. If artifacts don't exist, the gate doesn't pass.",
+      items: [
+        { id: "G0", phase: "Foundation", title: "Problem & Solution Validated",
+          ev: ["5+ user interviews documented", "100+ ideas generated, top 3 selected", "Personas evidence-based"] },
+        { id: "G1", phase: "Planning", title: "Requirements Complete",
+          ev: ["BDD requirements written", "Stakeholders signed off", "Acceptance criteria measurable"] },
+        { id: "G2", phase: "Design", title: "Architecture Approved",
+          ev: ["ADRs reviewed by CTO/Tech Lead", "Threat model complete", "API contracts in version control"] },
+        { id: "G3", phase: "Build · Test", title: "Ship-Ready",
+          ev: ["Tier coverage met (70/85/95%)", "OWASP API Top-10 checked", "MRP submitted for >100 LOC"] },
+        { id: "G4", phase: "Deploy · Operate", title: "Production Stable",
+          ev: ["Rollback procedure tested", "Monitoring dashboards live", "SLOs defined and tracked"] },
+      ]
+    },
+    vibe: {
+      eyebrow: "Section 7",
+      title: "The Vibecoding Index.",
+      body: "Vibecoded code is fast to write, expensive to maintain. The Index quantifies risk on a 0–100 scale across five weighted signals, then routes each PR to the right reviewer.",
+      signals: [
+        { l: "Intent Clarity", w: "30%" },
+        { l: "Code Ownership Confidence", w: "25%" },
+        { l: "Context Completeness", w: "20%" },
+        { l: "AI Attestation Rate", w: "15%" },
+        { l: "Historical Rejection Rate", w: "10%" },
+      ],
+      routing: [
+        { range: "0–19", label: "Green", action: "Auto-merge · 1+ approvals" },
+        { range: "20–39", label: "Yellow", action: "Tech Lead spot-check" },
+        { range: "40–59", label: "Orange", action: "CEO optional · Senior eng review" },
+        { range: "60–100", label: "Red", action: "Senior Review Board · CTO override" },
+      ]
+    },
+    souls: {
+      eyebrow: "Pillar 5 · SASE 13-Role Model",
+      title: "Eighteen role templates. Pre-tuned, battle-tested.",
+      sub: "Each SOUL specifies identity, stage coverage, gate responsibilities, and tier availability. Plug-and-play across projects.",
+      tiers: [
+        { l: "Advisor (SE4H)", c: "advisor" },
+        { l: "Executor (SE4A)", c: "executor" },
+        { l: "Support / Optional", c: "support" },
+      ],
+      items: [
+        { role: "Router", name: "assistant", c: "support" },
+        { role: "Advisor", name: "ceo", c: "advisor" },
+        { role: "Advisor", name: "cto", c: "advisor" },
+        { role: "Advisor", name: "cpo", c: "advisor" },
+        { role: "Advisor", name: "cso", c: "advisor" },
+        { role: "Executor", name: "coder", c: "executor" },
+        { role: "Executor", name: "fullstack", c: "executor" },
+        { role: "Executor", name: "architect", c: "executor" },
+        { role: "Executor", name: "tester", c: "executor" },
+        { role: "Executor", name: "reviewer", c: "executor" },
+        { role: "Executor", name: "devops", c: "executor" },
+        { role: "Executor", name: "pm", c: "executor" },
+        { role: "Executor", name: "pjm", c: "executor" },
+        { role: "Researcher", name: "researcher", c: "executor" },
+        { role: "Optional", name: "writer", c: "support" },
+        { role: "Optional", name: "sales", c: "support" },
+        { role: "Optional", name: "cs", c: "support" },
+        { role: "Optional", name: "itadmin", c: "support" },
+      ],
+    },
+    training: {
+      eyebrow: "11 Modules · 39 hours",
+      title: "Train your whole team in one curriculum.",
+      sub: "Real-incident-driven content. Each module ends with quiz + practical exercises. 80-question final assessment, 70% to pass.",
+      items: [
+        { i: "01", t: "SDLC Overview", sub: "10-Stage Lifecycle · 7 Pillars · 4-Tier Classification", h: "4h", tier: "ALL" },
+        { i: "02", t: "Six Pillars Deep Dive", sub: "Design Thinking · Zero Mock · QA · Documentation", h: "6h", tier: "ALL" },
+        { i: "03", t: "Zero Mock Policy", sub: "The 679 Mock Crisis · Real-services testing", h: "4h", tier: "STD+" },
+        { i: "04", t: "Code Quality Standards", sub: "Coverage · Naming · OWASP · Performance", h: "4h", tier: "STD+" },
+        { i: "05", t: "Development Workflow", sub: "Git · Conventional commits · 3-tier review · CI/CD", h: "4h", tier: "STD+" },
+        { i: "06", t: "AI Tools in Practice", sub: "Claude Code · Local models · Design-to-code", h: "4h", tier: "ALL" },
+        { i: "07", t: "SASE & Agentic SDLC", sub: "SE4H vs SE4A · 6 artifacts · L0–L3 maturity", h: "4h", tier: "PRO+" },
+        { i: "08", t: "Authority & Decision Governance", sub: "Role boundaries · 13 decision types · Escalation", h: "2h", tier: "PRO+" },
+        { i: "09", t: "Quality Gate Workshop", sub: "G0–G4 hands-on · Evidence upload · Common failures", h: "2h", tier: "STD+" },
+        { i: "10", t: "ADR & Sprint Plan Workflow", sub: "When ADR is mandatory · Document-first culture", h: "2h", tier: "STD+" },
+        { i: "11", t: "Remote Team Governance", sub: "Collaborator vs Fork · Remote escalation patterns", h: "1h", tier: "PRO+" },
+      ]
+    },
+    refs: {
+      eyebrow: "Reference implementations",
+      title: "Methodology + Platforms. Each in its lane.",
+      sub: "The Framework is tool-agnostic. Platforms implement the Framework. One Framework, many possible platforms.",
+      endior: {
+        badge: "LIVE · OPEN SOURCE",
+        title: "Endiorbot",
+        body: "Personal AI orchestration for solo developers. 14 SOUL agents across 5 channels. The first reference implementation of SDLC 6.3.1 — battle-tested, MIT-licensed, free forever.",
+        stats: [["1.2k", "GitHub stars"], ["14", "SOUL agents"], ["5", "channels"], ["Sprint 144", "current"]],
+        ctas: [["Visit endior.net", "https://endior.net"], ["GitHub →", "https://github.com/Minh-Tam-Solution/EndiorBot"]],
+      },
+      orch: {
+        badge: "COMING Q3 2026 · COMMERCIAL",
+        title: "SDLC Orchestrator",
+        body: "Enterprise platform that automates Framework enforcement. Dynamic AGENTS.md, gate automation, evidence collection, audit trails. Built for regulated teams that need governance at scale.",
+        stats: [["Q3", "2026 launch"], ["Enterprise", "tier focus"], ["Auto", "gate enforcement"], ["Pilot", "joining now"]],
+        ctas: [["Visit sdlc.nhatquangholding.com", "#"], ["Read the architecture", "#"]],
+      }
+    },
+    adopt: {
+      eyebrow: "Adoption",
+      title: "Three weeks from zero to compliant.",
+      sub: "Don't try to adopt all 7 pillars in one sprint. The framework is designed to be adopted incrementally — start small, prove value, expand.",
+      steps: [
+        { day: "Day 1", num: "01", t: "Read the Executive Summary",
+          d: "30 minutes. Understand 7 pillars, pick your tier, identify 1 stage to pilot." },
+        { day: "Week 1", num: "02", t: "Pilot one feature",
+          d: "Run a single feature through your chosen tier. Use templates verbatim. Don't customize yet." },
+        { day: "Week 2", num: "03", t: "Add quality gates",
+          d: "Wire G0–G4 into your CI/CD. Set Vibecoding Index to WARNING mode. Establish baseline." },
+        { day: "Week 3", num: "04", t: "Train the team",
+          d: "Run Modules 01 + 02 (10h). Switch governance to SOFT mode. Plan Module 06 for next month." },
+      ]
+    },
+    standards: {
+      eyebrow: "Standards alignment",
+      title: "Plays nicely with what you already have.",
+      sub: "SDLC 6.3.1 is a methodology, not a religion. It maps cleanly to industry standards your auditors already accept.",
+      items: [
+        ["CMMI v3.0", "Maturity levels (LITE = L1–2, ENTERPRISE = L4–5)"],
+        ["SAFe 6.0", "Lean Governance concepts"],
+        ["DORA Metrics", "Deployment Frequency · Lead Time · MTTR · CFR"],
+        ["OWASP ASVS", "Security Verification Levels 1–3"],
+        ["NIST SSDF", "Secure Development Framework"],
+        ["ISO/IEC 12207", "Process group alignment"],
+        ["Team Topologies", "4 fundamental team types"],
+        ["Singapore AI Gov", "Model AI Governance Framework (Jan 2026)"],
+      ]
+    },
+    faq: {
+      eyebrow: "FAQ",
+      title: "Honest answers.",
+      items: [
+        { q: "Is this another AI hype framework?",
+          a: "No. SDLC 6.3.1 has been battle-tested in production across 14 platforms in the NQH Technology Ecosystem. Every pillar is derived from real incidents, not hypotheticals. The case studies (BFlow 4.2→4.3, MTEP, NQH-Bot) are documented in /06-Case-Studies/." },
+        { q: "Do I need an AI tool to use this?",
+          a: "No. The framework is tool-agnostic. You can run all 10 stages manually with your existing tools. Platforms (like SDLC Orchestrator) automate enforcement, but humans following this framework on paper still get the benefit." },
+        { q: "How is this different from SAFe or CMMI?",
+          a: "SAFe was written for human-only teams. CMMI predates LLMs. SDLC 6.3.1 was built BY AI+Human teams, FOR AI+Human teams. It treats AI as a first-class citizen with explicit governance (SE4H/SE4A, AGENTS.md, CRP/MRP/VCR) — not as a productivity hack." },
+        { q: "Why MIT license?",
+          a: "Methodologies improve through adoption and adversarial review. Locking SDLC behind a license would slow the feedback loop. The Framework is free; only platforms that automate it (Orchestrator) are commercial." },
+        { q: "What's the relationship to Endiorbot?",
+          a: "Endiorbot is the first reference implementation of this Framework. When you read about Pillar 5 (SASE) here, Endiorbot's 14 agents are exactly what that looks like in practice. The two projects are co-developed, dual-launched." },
+        { q: "Will SDLC Orchestrator replace this Framework?",
+          a: "Never. The Framework is the policy. The Orchestrator is one platform that automates the policy. Other platforms (custom CI/CD, future tools) can implement the same Framework. 1 Framework : N platforms." },
+      ]
+    },
+    footer: {
+      tag: "SDLC Enterprise Framework v6.3.1",
+      sub: "Built BY AI+Human teams. FOR AI+Human teams. MIT licensed.",
+      cols: [
+        { t: "Framework", links: [["Executive Summary", "#"], ["Quick Reference", "#"], ["Core Methodology", "#"], ["Changelog", "#"]] },
+        { t: "Pillars", links: [["10-Stage Lifecycle", "#"], ["Quality Gates", "#"], ["SASE", "#"], ["Specifications", "#"]] },
+        { t: "Resources", links: [["18 SOUL templates", "#"], ["Case studies", "#"], ["Training (39h)", "#"], ["GitHub", "#"]] },
+        { t: "Family", links: [["Endiorbot (live)", "https://endior.net"], ["SDLC Orchestrator", "#"], ["NQH Ecosystem", "#"], ["MTS-SDLC-Lite", "https://github.com/Minh-Tam-Solution/MTS-SDLC-Lite"], ["TinySDLC", "https://github.com/Minh-Tam-Solution/tinysdlc"], ["AncestorTree", "https://github.com/Minh-Tam-Solution/AncestorTree"]] },
+      ],
+      auth: "CPO Office · taidt@mtsolution.com.vn · CTO Approved",
+    }
+  },
+  vi: {
+    nav: { framework: "Framework", endiorbot: "Endiorbot", orchestrator: "Orchestrator", lang: "VI" },
+    hero: {
+      eyebrow: "v6.3.1 · Tháng 4, 2026 · Giấy phép MIT",
+      headline_a: "Phương pháp 7-trụ-cột cho",
+      headline_em: "đội AI + Người",
+      headline_b: "thực sự ship được sản phẩm.",
+      sub: "Tool-agnostic. Đã kiểm chứng production. 503 tài liệu, 39 giờ đào tạo, 18 SOUL roles, 10 stages, 5 quality gates — tất cả mã nguồn mở.",
+      ctaPrimary: "Đọc Executive Summary",
+      ctaSecondary: "Xem reference: Endiorbot →",
+      stat1: { n: "11", l: "modules đào tạo" },
+      stat2: { n: "39h", l: "chương trình" },
+      stat3: { n: "18", l: "SOUL roles" },
+      stat4: { n: "10", l: "lifecycle stages" },
+      stat5: { n: "503+", l: "tài liệu" },
+    },
+    promise: {
+      eyebrow: "Lời cam kết",
+      title: "Xây dựng BỞI đội AI+Người. CHO đội AI+Người.",
+      body: "Hầu hết SDLC framework được viết trước khi LLM tồn tại. Chúng coi AI như công cụ gắn thêm. SDLC 6.3.1 bắt đầu từ tiền đề khác: con người định hướng, agent thực thi, con người xác minh — ở mọi giai đoạn, có bằng chứng, có gate, có trách nhiệm. Framework là phần còn lại sau khi loại bỏ mọi giả định rằng AI không tồn tại.",
+    },
+    pillars: {
+      eyebrow: "Pillar 0 → 6 + Section 7 + 8",
+      title: "Bảy trụ cột, hai mở rộng.",
+      sub: "Mỗi trụ cột độc lập. Áp dụng một hay cả bảy — framework scale từ solo developer tới enterprise.",
+      items: [
+        { n: "P0", t: "Design Thinking", d: "Empathize → Define → Ideate → Prototype → Test. Xác minh vấn đề trước khi xây giải pháp. Cắt tỷ lệ lãng phí 70% mà ngành công nghệ vẫn âm thầm chấp nhận." },
+        { n: "P1", t: "10-Stage Lifecycle", d: "Foundation → Govern. Mỗi stage có prerequisites, exit criteria và yêu cầu theo tier rõ ràng. Skip stage có chủ đích, không phải vô tình." },
+        { n: "P2", t: "Sprint Governance", d: "Sprint 3-pha với TDD tích hợp sẵn. G-Sprint và G-Sprint-Close. Quy tắc tài liệu trong 24h. Mười nguyên tắc vàng cho sprint." },
+        { n: "P3", t: "4-Tier Classification", d: "LITE (1-2 dev) → STANDARD → PROFESSIONAL → ENTERPRISE (50+). Tier quyết định stages bắt buộc, độ sâu tài liệu, tooling — không ngược lại." },
+        { n: "P4", t: "Quality Gates", d: "Dual-track: feature (G0–G4) và sprint (G-Sprint). Pass dựa trên bằng chứng. Không có artifact, không pass. Vibecoding Index lượng hoá rủi ro." },
+        { n: "P5", t: "SASE Integration", d: "Software Agent Software Engineering 3.0. SE4H (người hướng dẫn) vs SE4A (agent thực thi). AGENTS.md + CRP + MRP + VCR. Mô hình 13 vai trò chuẩn." },
+        { n: "P6", t: "Documentation Permanence", d: "Định dạng AI-parseable. Bắt buộc YAML frontmatter. BDD (GIVEN-WHEN-THEN). Spec là nguồn sự thật duy nhất — không phải Slack." },
+      ],
+      sec7: { n: "§7", t: "Quality Assurance System", d: "Anti-Vibecoding controls. Vibecoding Index (0–100). Routing tiến triển: green tự động merge → red CTO duyệt. Auto-generation giảm friction từ 30 phút xuống dưới 5 phút mỗi PR." },
+      sec8: { n: "§8", t: "Unified Specification Standard", d: "YAML frontmatter bắt buộc, BDD requirements, ADR nhẹ (DESIGN_DECISIONS), version tracking (SPEC_DELTA). SpecIR format-agnostic chuyển đổi OpenSpec ↔ SDLC hai chiều." },
+    },
+    stages: {
+      eyebrow: "Pillar 1",
+      title: "Mười stages. Mỗi stage hai câu hỏi.",
+      sub: "Click vào bất kỳ stage để xem prerequisites, exit gate và deliverables chính.",
+      data: [
+        { id: "00", name: "Foundation", q: "TẠI SAO?", gate: "G0.1 / G0.2", reqs: "—", parallel: "Không",
+          deliverables: [
+            ["Câu hỏi", "Tại sao chúng ta xây cái này?"],
+            ["Output", "Business case · Problem statement · 3 personas có bằng chứng"],
+            ["Gate", "G0.1 (vấn đề được xác minh, 5+ users) → G0.2 (đa dạng giải pháp, 100+ ý tưởng)"],
+            ["Rủi ro skip", "Critical — bỏ qua dẫn tới 70% lãng phí feature"],
+          ]
+        },
+        { id: "01", name: "Planning", q: "CÁI GÌ?", gate: "G1", reqs: "00 + G0.2", parallel: "Không",
+          deliverables: [
+            ["Câu hỏi", "Chúng ta xây cái gì?"],
+            ["Output", "Requirements · User stories · API specs · Acceptance criteria"],
+            ["Định dạng", "BDD (GIVEN-WHEN-THEN) bắt buộc từ STANDARD trở lên"],
+            ["Gate", "G1 — stakeholders duyệt, requirements đủ"],
+          ]
+        },
+        { id: "02", name: "Design", q: "BẰNG CÁCH NÀO?", gate: "G2", reqs: "01 + G1", parallel: "Không",
+          deliverables: [
+            ["Câu hỏi", "Chúng ta xây bằng cách nào?"],
+            ["Output", "Architecture · ADRs · Threat model · Security design"],
+            ["Templates", "ADR-NNN, SPEC-NNNN với YAML frontmatter"],
+            ["Gate", "G2 — CTO/Tech Lead duyệt"],
+          ]
+        },
+        { id: "03", name: "Integrate", q: "Kết nối?", gate: "G2", reqs: "02 + G2", parallel: "Có (với 04)",
+          deliverables: [
+            ["Câu hỏi", "Hệ thống kết nối thế nào?"],
+            ["Output", "API contracts · Integration tests · OpenAPI SSOT"],
+            ["Cross-ref", "Stage 03 ↔ Stage 05 traceability matrix"],
+            ["Pattern", "Song song với Build qua API-first development"],
+          ]
+        },
+        { id: "04", name: "Build", q: "Đúng chưa?", gate: "G3", reqs: "02 + G2", parallel: "Có (với 03)",
+          deliverables: [
+            ["Câu hỏi", "Chúng ta đang xây đúng không?"],
+            ["Output", "Code chạy được · Unit tests · Coverage đạt tier target"],
+            ["TDD", "RED → GREEN → REFACTOR mỗi feature"],
+            ["Coverage", "LITE 70% · STD 85% · PRO/ENT 95%"],
+          ]
+        },
+        { id: "05", name: "Test", q: "Chạy đúng?", gate: "G3", reqs: "04 + G3", parallel: "Không",
+          deliverables: [
+            ["Câu hỏi", "Hệ thống chạy đúng không?"],
+            ["Output", "Test reports · UAT sign-off · OWASP API Top-10"],
+            ["Workflow", "6-pha E2E: Discovery → Config → Execution → Security → Reporting → Integration"],
+            ["Tiết kiệm", "~83% thời gian setup so với test ad-hoc"],
+          ]
+        },
+        { id: "06", name: "Deploy", q: "Ship?", gate: "G4", reqs: "05 + G3", parallel: "Không",
+          deliverables: [
+            ["Câu hỏi", "Ship sao cho an toàn?"],
+            ["Output", "Release notes · Rollback procedures · Deployment evidence"],
+            ["Checklist", "100-mục Go-Live Readiness (theo tier)"],
+            ["Gate", "G4 — production ổn định"],
+          ]
+        },
+        { id: "07", name: "Operate", q: "Đang chạy?", gate: "Continuous", reqs: "06 + G4", parallel: "Có",
+          deliverables: [
+            ["Câu hỏi", "Hệ thống chạy ổn không?"],
+            ["Output", "Runbooks · Monitoring dashboards · SLO definitions"],
+            ["Metrics", "DORA: deployment frequency, lead time, MTTR, CFR"],
+            ["Mục tiêu", "99.9%+ uptime ở tier PRO/ENT"],
+          ]
+        },
+        { id: "08", name: "Collaborate", q: "Hiệu quả?", gate: "Continuous", reqs: "01+", parallel: "Có",
+          deliverables: [
+            ["Câu hỏi", "Đội nhóm có hiệu quả không?"],
+            ["Output", "Team charter · AGENTS.md · Tài liệu đào tạo"],
+            ["Roles", "Mô hình SASE 13 vai trò + 10 TEAM charters"],
+            ["Pattern", "Chạy xuyên suốt — không bao giờ block delivery"],
+          ]
+        },
+        { id: "09", name: "Govern", q: "Tuân thủ?", gate: "Continuous", reqs: "06 + G4", parallel: "Có",
+          deliverables: [
+            ["Câu hỏi", "Có tuân thủ không?"],
+            ["Output", "Compliance reports · Audit logs · Risk register"],
+            ["Standards", "SOC 2 · HIPAA · GDPR · NIST SSDF"],
+            ["Bắt đầu sớm", "Có thể bắt đầu từ Stage 01 nếu là ngành quản lý chặt"],
+          ]
+        },
+      ]
+    },
+    tiers: {
+      eyebrow: "Pillar 3",
+      title: "Một framework. Bốn tier.",
+      sub: "Chọn tier phù hợp với đội — đừng chọn tier cao hơn năng lực hiện tại. Framework scale xuống cũng nhẹ nhàng như scale lên.",
+      items: [
+        { lvl: "T1", name: "LITE", who: "1–2 dev · Solo · Indie", stages: "00, 01, 02, 04",
+          features: ["3 SOUL roles", "README + .env.example", "70% test coverage", "AGENTS.md <60 dòng"], rec: false },
+        { lvl: "T2", name: "STANDARD", who: "3–10 dev · Startup · Agency nhỏ", stages: "00–02, 04–06",
+          features: ["6 SOUL roles", "+ CLAUDE.md + /docs", "85% test coverage", "BDD requirements"], rec: true },
+        { lvl: "T3", name: "PROFESSIONAL", who: "10–50 dev · Growth-stage", stages: "Cả 10 stages",
+          features: ["11 SOUL roles", "+ Full ADRs + Compliance", "95% test coverage", "Senior review board"], rec: false },
+        { lvl: "T4", name: "ENTERPRISE", who: "50+ dev · Quản lý chặt · Đại chúng", stages: "Cả 10 stages",
+          features: ["14 SOUL roles", "+ Executive reports + Audit", "95%+ + security tests", "Tất cả sections"], rec: false },
+      ]
+    },
+    gates: {
+      eyebrow: "Pillar 4",
+      title: "Năm gates. Có bằng chứng mới qua.",
+      sub: "Quality gate không phải sự đồng ý — là điểm kiểm tra bằng chứng. Không có artifact, gate không pass.",
+      items: [
+        { id: "G0", phase: "Foundation", title: "Vấn đề & Giải pháp được xác minh",
+          ev: ["5+ user interviews có tài liệu", "100+ ý tưởng, chọn top 3", "Personas có bằng chứng"] },
+        { id: "G1", phase: "Planning", title: "Requirements đầy đủ",
+          ev: ["BDD requirements đã viết", "Stakeholders duyệt", "Acceptance criteria đo được"] },
+        { id: "G2", phase: "Design", title: "Architecture được duyệt",
+          ev: ["ADR được CTO/Tech Lead duyệt", "Threat model đầy đủ", "API contracts trong version control"] },
+        { id: "G3", phase: "Build · Test", title: "Sẵn sàng ship",
+          ev: ["Đạt coverage theo tier (70/85/95%)", "OWASP API Top-10 đã check", "MRP submit cho >100 LOC"] },
+        { id: "G4", phase: "Deploy · Operate", title: "Production ổn định",
+          ev: ["Rollback đã test", "Monitoring dashboards live", "SLO định nghĩa và theo dõi"] },
+      ]
+    },
+    vibe: {
+      eyebrow: "Section 7",
+      title: "Vibecoding Index.",
+      body: "Code 'vibe' viết nhanh, bảo trì tốn kém. Index lượng hoá rủi ro trên thang 0–100 qua năm signal có trọng số, sau đó route mỗi PR đến đúng người review.",
+      signals: [
+        { l: "Intent Clarity", w: "30%" },
+        { l: "Code Ownership Confidence", w: "25%" },
+        { l: "Context Completeness", w: "20%" },
+        { l: "AI Attestation Rate", w: "15%" },
+        { l: "Historical Rejection Rate", w: "10%" },
+      ],
+      routing: [
+        { range: "0–19", label: "Green", action: "Auto-merge · 1+ approvals" },
+        { range: "20–39", label: "Yellow", action: "Tech Lead spot-check" },
+        { range: "40–59", label: "Orange", action: "CEO optional · Senior review" },
+        { range: "60–100", label: "Red", action: "Senior Review Board · CTO override" },
+      ]
+    },
+    souls: {
+      eyebrow: "Pillar 5 · SASE 13-Role Model",
+      title: "Mười tám role templates. Pre-tuned, đã chinh chiến.",
+      sub: "Mỗi SOUL chỉ định identity, stage coverage, gate responsibilities và tier availability. Plug-and-play giữa các project.",
+      tiers: [
+        { l: "Advisor (SE4H)", c: "advisor" },
+        { l: "Executor (SE4A)", c: "executor" },
+        { l: "Support / Optional", c: "support" },
+      ],
+      items: [
+        { role: "Router", name: "assistant", c: "support" },
+        { role: "Advisor", name: "ceo", c: "advisor" },
+        { role: "Advisor", name: "cto", c: "advisor" },
+        { role: "Advisor", name: "cpo", c: "advisor" },
+        { role: "Advisor", name: "cso", c: "advisor" },
+        { role: "Executor", name: "coder", c: "executor" },
+        { role: "Executor", name: "fullstack", c: "executor" },
+        { role: "Executor", name: "architect", c: "executor" },
+        { role: "Executor", name: "tester", c: "executor" },
+        { role: "Executor", name: "reviewer", c: "executor" },
+        { role: "Executor", name: "devops", c: "executor" },
+        { role: "Executor", name: "pm", c: "executor" },
+        { role: "Executor", name: "pjm", c: "executor" },
+        { role: "Researcher", name: "researcher", c: "executor" },
+        { role: "Optional", name: "writer", c: "support" },
+        { role: "Optional", name: "sales", c: "support" },
+        { role: "Optional", name: "cs", c: "support" },
+        { role: "Optional", name: "itadmin", c: "support" },
+      ],
+    },
+    training: {
+      eyebrow: "11 Modules · 39 giờ",
+      title: "Đào tạo cả đội bằng một chương trình.",
+      sub: "Nội dung từ sự cố thật. Mỗi module có quiz + bài tập thực hành. Đánh giá cuối 80 câu, đạt 70% là pass.",
+      items: [
+        { i: "01", t: "SDLC Overview", sub: "10-Stage Lifecycle · 7 Pillars · 4-Tier Classification", h: "4h", tier: "ALL" },
+        { i: "02", t: "Six Pillars Deep Dive", sub: "Design Thinking · Zero Mock · QA · Documentation", h: "6h", tier: "ALL" },
+        { i: "03", t: "Zero Mock Policy", sub: "Khủng hoảng 679 Mock · Test với real services", h: "4h", tier: "STD+" },
+        { i: "04", t: "Code Quality Standards", sub: "Coverage · Naming · OWASP · Performance", h: "4h", tier: "STD+" },
+        { i: "05", t: "Development Workflow", sub: "Git · Conventional commits · 3-tier review · CI/CD", h: "4h", tier: "STD+" },
+        { i: "06", t: "AI Tools trong thực tế", sub: "Claude Code · Local models · Design-to-code", h: "4h", tier: "ALL" },
+        { i: "07", t: "SASE & Agentic SDLC", sub: "SE4H vs SE4A · 6 artifacts · L0–L3 maturity", h: "4h", tier: "PRO+" },
+        { i: "08", t: "Authority & Decision Governance", sub: "Role boundaries · 13 decision types · Escalation", h: "2h", tier: "PRO+" },
+        { i: "09", t: "Quality Gate Workshop", sub: "G0–G4 hands-on · Upload bằng chứng · Lỗi phổ biến", h: "2h", tier: "STD+" },
+        { i: "10", t: "ADR & Sprint Plan Workflow", sub: "Khi nào ADR bắt buộc · Document-first culture", h: "2h", tier: "STD+" },
+        { i: "11", t: "Remote Team Governance", sub: "Collaborator vs Fork · Escalation pattern remote", h: "1h", tier: "PRO+" },
+      ]
+    },
+    refs: {
+      eyebrow: "Reference implementations",
+      title: "Methodology + Platforms. Mỗi cái một làn.",
+      sub: "Framework tool-agnostic. Platform thực thi Framework. Một Framework, nhiều platform khả thi.",
+      endior: {
+        badge: "LIVE · MÃ NGUỒN MỞ",
+        title: "Endiorbot",
+        body: "AI orchestration cá nhân cho lập trình viên solo. 14 SOUL agents qua 5 kênh. Reference implementation đầu tiên của SDLC 6.3.1 — đã chinh chiến, MIT, miễn phí mãi mãi.",
+        stats: [["1.2k", "GitHub stars"], ["14", "SOUL agents"], ["5", "kênh"], ["Sprint 144", "hiện tại"]],
+        ctas: [["Vào endior.net", "https://endior.net"], ["GitHub →", "https://github.com/Minh-Tam-Solution/EndiorBot"]],
+      },
+      orch: {
+        badge: "RA MẮT Q3 2026 · THƯƠNG MẠI",
+        title: "SDLC Orchestrator",
+        body: "Nền tảng enterprise tự động hoá Framework. Dynamic AGENTS.md, gate automation, thu thập bằng chứng, audit trails. Dành cho team quản lý chặt cần governance ở quy mô lớn.",
+        stats: [["Q3", "ra mắt 2026"], ["Enterprise", "tier focus"], ["Auto", "gate enforcement"], ["Pilot", "đang mở"]],
+        ctas: [["Vào sdlc.nhatquangholding.com", "#"], ["Đọc kiến trúc", "#"]],
+      }
+    },
+    adopt: {
+      eyebrow: "Áp dụng",
+      title: "Ba tuần từ zero tới compliant.",
+      sub: "Đừng cố áp dụng cả 7 trụ cột trong một sprint. Framework thiết kế để adopt từng phần — bắt đầu nhỏ, chứng minh giá trị, mở rộng.",
+      steps: [
+        { day: "Ngày 1", num: "01", t: "Đọc Executive Summary",
+          d: "30 phút. Hiểu 7 trụ cột, chọn tier, xác định 1 stage để pilot." },
+        { day: "Tuần 1", num: "02", t: "Pilot một feature",
+          d: "Chạy một feature qua tier đã chọn. Dùng template y nguyên. Chưa customize." },
+        { day: "Tuần 2", num: "03", t: "Thêm quality gates",
+          d: "Wire G0–G4 vào CI/CD. Set Vibecoding Index ở chế độ WARNING. Lập baseline." },
+        { day: "Tuần 3", num: "04", t: "Đào tạo đội",
+          d: "Chạy Module 01 + 02 (10h). Chuyển governance sang chế độ SOFT. Lên kế hoạch Module 06 cho tháng sau." },
+      ]
+    },
+    standards: {
+      eyebrow: "Chuẩn ngành",
+      title: "Tương thích với mọi thứ bạn đã có.",
+      sub: "SDLC 6.3.1 là phương pháp, không phải tôn giáo. Map sạch sẽ với các chuẩn ngành mà auditor đã chấp nhận.",
+      items: [
+        ["CMMI v3.0", "Maturity levels (LITE = L1–2, ENTERPRISE = L4–5)"],
+        ["SAFe 6.0", "Lean Governance concepts"],
+        ["DORA Metrics", "Deployment Frequency · Lead Time · MTTR · CFR"],
+        ["OWASP ASVS", "Security Verification Levels 1–3"],
+        ["NIST SSDF", "Secure Development Framework"],
+        ["ISO/IEC 12207", "Process group alignment"],
+        ["Team Topologies", "4 loại team cơ bản"],
+        ["Singapore AI Gov", "Model AI Governance Framework (1/2026)"],
+      ]
+    },
+    faq: {
+      eyebrow: "FAQ",
+      title: "Trả lời thẳng thắn.",
+      items: [
+        { q: "Đây có phải framework AI hype nữa không?",
+          a: "Không. SDLC 6.3.1 đã được battle-test ở production qua 14 platform trong NQH Technology Ecosystem. Mỗi trụ cột bắt nguồn từ sự cố thật, không phải giả định. Case studies (BFlow 4.2→4.3, MTEP, NQH-Bot) có tài liệu trong /06-Case-Studies/." },
+        { q: "Có cần AI tool để dùng framework này không?",
+          a: "Không. Framework tool-agnostic. Có thể chạy thủ công cả 10 stages với công cụ hiện có. Platform (như SDLC Orchestrator) tự động hoá enforcement, nhưng người làm theo framework trên giấy vẫn được hưởng lợi." },
+        { q: "Khác gì SAFe hoặc CMMI?",
+          a: "SAFe viết cho team chỉ có người. CMMI có trước LLM. SDLC 6.3.1 được xây BỞI đội AI+Người, CHO đội AI+Người. Coi AI là công dân hạng nhất với governance rõ ràng (SE4H/SE4A, AGENTS.md, CRP/MRP/VCR) — không phải mẹo tăng productivity." },
+        { q: "Vì sao MIT?",
+          a: "Methodology cải thiện qua adoption và phản biện. Khoá SDLC sau license sẽ làm chậm feedback loop. Framework miễn phí; chỉ platform tự động hoá nó (Orchestrator) là thương mại." },
+        { q: "Quan hệ với Endiorbot là gì?",
+          a: "Endiorbot là reference implementation đầu tiên của Framework. Khi đọc về Pillar 5 (SASE) ở đây, 14 agents của Endiorbot chính là hình hài thực tế. Hai project co-developed, dual-launch." },
+        { q: "SDLC Orchestrator có thay thế Framework này không?",
+          a: "Không bao giờ. Framework là chính sách. Orchestrator là một platform tự động hoá chính sách đó. Platform khác (custom CI/CD, công cụ tương lai) có thể implement cùng Framework. 1 Framework : N platforms." },
+      ]
+    },
+    footer: {
+      tag: "SDLC Enterprise Framework v6.3.1",
+      sub: "Xây BỞI đội AI+Người. CHO đội AI+Người. MIT licensed.",
+      cols: [
+        { t: "Framework", links: [["Executive Summary", "#"], ["Quick Reference", "#"], ["Core Methodology", "#"], ["Changelog", "#"]] },
+        { t: "Pillars", links: [["10-Stage Lifecycle", "#"], ["Quality Gates", "#"], ["SASE", "#"], ["Specifications", "#"]] },
+        { t: "Resources", links: [["18 SOUL templates", "#"], ["Case studies", "#"], ["Training (39h)", "#"], ["GitHub", "#"]] },
+        { t: "Family", links: [["Endiorbot (live)", "https://endior.net"], ["SDLC Orchestrator", "#"], ["NQH Ecosystem", "#"], ["MTS-SDLC-Lite", "https://github.com/Minh-Tam-Solution/MTS-SDLC-Lite"], ["TinySDLC", "https://github.com/Minh-Tam-Solution/tinysdlc"], ["AncestorTree", "https://github.com/Minh-Tam-Solution/AncestorTree"]] },
+      ],
+      auth: "CPO Office · taidt@mtsolution.com.vn · CTO Approved",
+    }
+  }
+};
+window.sdlcCopy = sdlcCopy;

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" data-site="sdlc" data-theme="rust" data-density="cozy">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>SDLC Enterprise Framework v6.3.1 — Built BY AI+Human teams. FOR AI+Human teams.</title>
+<meta name="description" content="A 7-pillar methodology for AI+Human engineering teams. 10-stage lifecycle, 4 tiers, 5 quality gates, 18 SOUL roles. Tool-agnostic, MIT-licensed, battle-tested in production." />
+<meta property="og:title" content="SDLC Enterprise Framework v6.3.1" />
+<meta property="og:description" content="Built BY AI+Human teams. FOR AI+Human teams. Open methodology with reference implementations." />
+
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..600;1,9..144,300..500&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='6' r='2.2' fill='%23c8553d'/%3E%3Ccircle cx='24.7' cy='10' r='2.2' fill='%23c8553d'/%3E%3Ccircle cx='25.5' cy='19.7' r='2.2' fill='%23c8553d'/%3E%3Ccircle cx='19.5' cy='25.7' r='2.2' fill='%23c8553d'/%3E%3Ccircle cx='12.5' cy='25.7' r='2.2' fill='%23c8553d'/%3E%3Ccircle cx='6.5' cy='19.7' r='2.2' fill='%23c8553d'/%3E%3Ccircle cx='7.3' cy='10' r='2.2' fill='%23c8553d'/%3E%3Ccircle cx='16' cy='16' r='2.4' fill='none' stroke='%23f3eee5' stroke-width='1.2'/%3E%3C/svg%3E" />
+
+<link rel="stylesheet" href="styles.css" />
+<link rel="stylesheet" href="styles-sdlc.css" />
+</head>
+<body>
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script src="copy-sdlc.js"></script>
+<script type="text/babel" src="tweaks-panel.jsx"></script>
+<script type="text/babel" src="components-base.jsx"></script>
+<script type="text/babel" src="components-sdlc.jsx"></script>
+<script type="text/babel" src="app-sdlc.jsx"></script>
+</body>
+</html>

--- a/site/styles-sdlc.css
+++ b/site/styles-sdlc.css
@@ -1,0 +1,282 @@
+/* SDLC Framework — palette + page-specific styles
+   Sibling of styles.css; loaded after it to shift accents. */
+
+[data-site="sdlc"] {
+  --bg: #0c0a09;
+  --bg-1: #131110;
+  --bg-2: #1a1715;
+  --bg-3: #221d1a;
+  --line: rgba(255,255,255,0.07);
+  --line-2: rgba(255,255,255,0.13);
+  --ink: #f3eee5;
+  --ink-2: #b6ad9d;
+  --ink-3: #7a7163;
+  --accent: #c8553d;       /* deep rust */
+  --accent-2: #e07658;
+  --accent-soft: rgba(200, 85, 61, 0.13);
+  --term: #d8b26b;         /* warm gold instead of green */
+  --term-soft: rgba(216, 178, 107, 0.14);
+  --violet: #9d8fd1;
+}
+
+[data-site="sdlc"][data-theme="paper"] {
+  --bg: #f1ece1;
+  --bg-1: #e8e1d2;
+  --bg-2: #dfd6c2;
+  --bg-3: #d0c4ab;
+  --line: rgba(0,0,0,0.10);
+  --line-2: rgba(0,0,0,0.18);
+  --ink: #1c1714;
+  --ink-2: #4a4137;
+  --ink-3: #7a6f60;
+  --accent: #a83a25;
+  --accent-2: #c45336;
+  --accent-soft: rgba(168, 58, 37, 0.10);
+}
+[data-site="sdlc"][data-theme="cobalt"] {
+  --accent: #6ea8ff;
+  --accent-2: #9cc1ff;
+  --accent-soft: rgba(110, 168, 255, 0.12);
+}
+[data-site="sdlc"][data-theme="ink"] {
+  --bg: #08080a;
+  --bg-1: #0e0e10;
+  --bg-2: #131316;
+  --bg-3: #19191c;
+  --accent: #f3eee5;
+  --accent-2: #ffffff;
+  --accent-soft: rgba(243, 238, 229, 0.08);
+}
+
+/* Pillars grid — 7 cards */
+.pillars-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;
+}
+.pillars-grid .p7 { grid-column: span 1; }
+.pillar-card {
+  position: relative;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 24px 22px 22px;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 180px;
+  transition: border-color .18s, transform .18s;
+}
+.pillar-card:hover { border-color: var(--line-2); transform: translateY(-2px); }
+.pillar-card .num {
+  font-family: var(--font-display); font-size: 36px; line-height: 1;
+  color: var(--accent); font-weight: 400; letter-spacing: -0.02em;
+}
+.pillar-card h4 {
+  font-family: var(--font-display); font-size: 19px; font-weight: 500;
+  letter-spacing: -0.015em; margin: 0; color: var(--ink);
+}
+.pillar-card p {
+  margin: auto 0 0; font-size: 13px; color: var(--ink-2); line-height: 1.55;
+}
+@media (max-width: 980px) { .pillars-grid { grid-template-columns: repeat(2, 1fr); } }
+
+/* 10-Stage timeline */
+.stages-timeline {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--bg-1);
+  overflow: hidden;
+  margin-bottom: 24px;
+}
+.stage-cell {
+  border-right: 1px solid var(--line);
+  padding: 18px 14px;
+  display: flex; flex-direction: column; gap: 8px;
+  min-height: 140px;
+  cursor: pointer;
+  transition: background .18s;
+}
+.stage-cell:last-child { border-right: 0; }
+.stage-cell:hover, .stage-cell[aria-selected="true"] { background: var(--bg-2); }
+.stage-cell .sid {
+  font-family: var(--font-mono); font-size: 11px;
+  letter-spacing: 0.08em; color: var(--ink-3);
+}
+.stage-cell .sname {
+  font-family: var(--font-display); font-size: 15px;
+  letter-spacing: -0.01em; color: var(--ink);
+  text-wrap: balance;
+}
+.stage-cell .sgate {
+  margin-top: auto;
+  font-family: var(--font-mono); font-size: 10.5px;
+  letter-spacing: 0.05em; color: var(--accent);
+}
+.stage-cell[aria-selected="true"] {
+  box-shadow: inset 0 -3px 0 var(--accent);
+}
+.stage-detail {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--bg-1);
+  padding: 28px;
+  display: grid; grid-template-columns: 1fr 1.4fr; gap: 32px;
+}
+.stage-detail h3 { font-size: 28px; }
+.stage-detail .meta { display: flex; gap: 18px; flex-wrap: wrap; font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-3); }
+.stage-detail .meta strong { color: var(--ink); font-weight: 500; }
+.stage-detail ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
+.stage-detail ul li { display: flex; gap: 10px; font-size: 13.5px; color: var(--ink-2); }
+.stage-detail ul li .k { font-family: var(--font-mono); color: var(--accent); flex-shrink: 0; width: 70px; }
+@media (max-width: 1100px) {
+  .stages-timeline { grid-template-columns: repeat(5, 1fr); }
+  .stage-cell:nth-child(5) { border-right: 0; }
+  .stage-detail { grid-template-columns: 1fr; }
+}
+@media (max-width: 720px) { .stages-timeline { grid-template-columns: repeat(2, 1fr); } .stage-cell { border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); } }
+
+/* 4-Tier ladder */
+.tiers-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+.tier-card {
+  background: var(--bg-1); border: 1px solid var(--line); border-radius: 14px;
+  padding: 24px 22px;
+  display: flex; flex-direction: column; gap: 14px;
+  position: relative;
+}
+.tier-card[data-rec="true"] { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent-soft); }
+.tier-card[data-rec="true"]::after {
+  content: "Most adopted";
+  position: absolute; top: -10px; right: 16px;
+  background: var(--accent); color: #1a0f0c;
+  font-family: var(--font-mono); font-size: 10px;
+  letter-spacing: 0.08em; padding: 3px 10px; border-radius: 999px;
+}
+.tier-card .lvl { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; color: var(--ink-3); }
+.tier-card h4 { font-family: var(--font-display); font-size: 28px; letter-spacing: -0.025em; }
+.tier-card .who { font-size: 13px; color: var(--ink-2); }
+.tier-card ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px; }
+.tier-card ul li { font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-2); display: flex; gap: 8px; }
+.tier-card ul li::before { content: "▸"; color: var(--accent); }
+.tier-card .num { font-family: var(--font-display); font-size: 22px; color: var(--ink); font-weight: 400; }
+.tier-card .num em { color: var(--accent); font-style: normal; }
+@media (max-width: 980px) { .tiers-grid { grid-template-columns: repeat(2, 1fr); } }
+
+/* SOUL templates */
+.souls-grid {
+  display: grid; grid-template-columns: repeat(6, 1fr); gap: 8px;
+}
+.soul-cell {
+  background: var(--bg-1); border: 1px solid var(--line);
+  border-radius: 10px; padding: 14px 14px;
+  display: flex; flex-direction: column; gap: 6px;
+  min-height: 92px;
+  transition: border-color .18s, transform .18s;
+}
+.soul-cell:hover { border-color: var(--line-2); transform: translateY(-1px); }
+.soul-cell .role { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.05em; text-transform: uppercase; }
+.soul-cell .name { font-family: var(--font-display); font-size: 17px; color: var(--ink); letter-spacing: -0.015em; }
+.soul-cell.advisor { box-shadow: inset 3px 0 0 var(--violet); }
+.soul-cell.executor { box-shadow: inset 3px 0 0 var(--accent); }
+.soul-cell.support { box-shadow: inset 3px 0 0 var(--ink-3); }
+@media (max-width: 1100px) { .souls-grid { grid-template-columns: repeat(4, 1fr); } }
+@media (max-width: 640px)  { .souls-grid { grid-template-columns: repeat(2, 1fr); } }
+
+/* Training modules */
+.modules-list {
+  border: 1px solid var(--line); border-radius: 14px;
+  background: var(--bg-1); overflow: hidden;
+}
+.module-row {
+  display: grid; grid-template-columns: 60px 1fr 90px 100px;
+  gap: 16px; align-items: center;
+  padding: 16px 22px;
+  border-bottom: 1px solid var(--line);
+  transition: background .18s;
+}
+.module-row:last-child { border-bottom: 0; }
+.module-row:hover { background: var(--bg-2); }
+.module-row .midx { font-family: var(--font-mono); font-size: 12px; color: var(--accent); letter-spacing: 0.05em; }
+.module-row .mtitle { font-size: 15px; color: var(--ink); }
+.module-row .mtitle small { display: block; color: var(--ink-3); font-size: 12px; margin-top: 2px; }
+.module-row .mhrs { font-family: var(--font-mono); font-size: 12px; color: var(--ink-2); text-align: right; }
+.module-row .mtier { font-family: var(--font-mono); font-size: 10.5px; color: var(--ink-3); letter-spacing: 0.05em; text-align: right; }
+@media (max-width: 720px) {
+  .module-row { grid-template-columns: 40px 1fr 70px; }
+  .module-row .mtier { display: none; }
+}
+
+/* Reference implementations */
+.refs-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.ref-card {
+  background: var(--bg-1); border: 1px solid var(--line); border-radius: 18px;
+  padding: 32px;
+  display: flex; flex-direction: column; gap: 16px;
+  position: relative; overflow: hidden;
+}
+.ref-card.live::before {
+  content: ""; position: absolute; inset: -40% -10% auto auto;
+  width: 60%; height: 60%; border-radius: 50%;
+  background: radial-gradient(circle, var(--accent-soft), transparent 60%);
+  pointer-events: none;
+}
+.ref-card .badge {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 4px 12px; border-radius: 999px;
+  font-family: var(--font-mono); font-size: 10.5px;
+  letter-spacing: 0.08em; color: var(--ink-2);
+  background: var(--bg-3); border: 1px solid var(--line-2);
+  width: fit-content;
+}
+.ref-card.live .badge { background: var(--accent-soft); color: var(--accent); border-color: var(--accent); }
+.ref-card .badge .live { width: 6px; height: 6px; border-radius: 50%; background: currentColor; animation: pulse 2.4s ease-in-out infinite; }
+.ref-card h3 { font-family: var(--font-display); font-size: 30px; letter-spacing: -0.025em; color: var(--ink); }
+.ref-card p { font-size: 14px; color: var(--ink-2); }
+.ref-card .stats { display: flex; gap: 28px; flex-wrap: wrap; padding-top: 16px; border-top: 1px solid var(--line); margin-top: auto; }
+.ref-card .stats div .num { font-family: var(--font-display); font-size: 24px; color: var(--ink); }
+.ref-card .stats div .lbl { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.06em; color: var(--ink-3); margin-top: 2px; }
+.ref-card .ctas { display: flex; gap: 10px; flex-wrap: wrap; }
+@media (max-width: 980px) { .refs-grid { grid-template-columns: 1fr; } }
+
+/* Adoption sequence */
+.adopt-rail {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+  border: 1px solid var(--line); border-radius: 14px; overflow: hidden;
+}
+.adopt-step {
+  padding: 28px 26px; border-right: 1px solid var(--line);
+  display: flex; flex-direction: column; gap: 10px; min-height: 200px;
+  background: var(--bg-1);
+}
+.adopt-step:last-child { border-right: 0; }
+.adopt-step .day { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; color: var(--accent); }
+.adopt-step .num { font-family: var(--font-display); font-size: 44px; line-height: 1; color: var(--ink-3); font-weight: 300; }
+.adopt-step h4 { font-family: var(--font-display); font-size: 18px; letter-spacing: -0.01em; color: var(--ink); margin: 0; }
+.adopt-step p { font-size: 13px; color: var(--ink-2); margin: 0; }
+@media (max-width: 980px) { .adopt-rail { grid-template-columns: repeat(2, 1fr); } .adopt-step:nth-child(2) { border-right: 0; } .adopt-step:nth-child(-n+2) { border-bottom: 1px solid var(--line); } }
+@media (max-width: 540px) { .adopt-rail { grid-template-columns: 1fr; } .adopt-step { border-right: 0; border-bottom: 1px solid var(--line); } .adopt-step:last-child { border-bottom: 0; } }
+
+/* Vibecoding meter */
+.vibe-wrap { display: grid; grid-template-columns: 1fr 1fr; gap: 36px; align-items: center; }
+.vibe-meter {
+  background: var(--bg-1); border: 1px solid var(--line); border-radius: 14px;
+  padding: 28px;
+}
+.vibe-meter .scale {
+  display: flex; height: 14px; border-radius: 999px; overflow: hidden;
+  background: var(--bg-3);
+}
+.vibe-meter .scale i { display: block; height: 100%; }
+.vibe-meter .scale .a { background: #6b3a30; flex: 0 0 25%; }
+.vibe-meter .scale .b { background: #a8553a; flex: 0 0 25%; }
+.vibe-meter .scale .c { background: #c8553d; flex: 0 0 25%; }
+.vibe-meter .scale .d { background: var(--accent-2); flex: 0 0 25%; }
+.vibe-meter .ticks {
+  display: flex; justify-content: space-between; margin-top: 8px;
+  font-family: var(--font-mono); font-size: 11px; color: var(--ink-3);
+}
+.vibe-meter .ticks .now {
+  color: var(--accent);
+}
+.vibe-meter h4 { font-family: var(--font-display); font-size: 20px; margin-bottom: 4px; }
+.vibe-meter .row { display: flex; justify-content: space-between; padding: 8px 0; border-top: 1px dashed var(--line); font-size: 13px; color: var(--ink-2); margin-top: 8px; }
+.vibe-meter .row span:last-child { font-family: var(--font-mono); color: var(--ink); }
+@media (max-width: 980px) { .vibe-wrap { grid-template-columns: 1fr; } }

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,610 @@
+/* ========================================================================
+   Endiorbot — Landing styles
+   Aesthetic: editorial dark + terminal accents, warm amber accent
+   ======================================================================== */
+
+:root {
+  /* Default theme: warm-amber on near-black */
+  --bg: #0b0b0c;
+  --bg-1: #111113;
+  --bg-2: #161618;
+  --bg-3: #1d1d20;
+  --line: rgba(255, 255, 255, 0.08);
+  --line-2: rgba(255, 255, 255, 0.14);
+  --ink: #f4f1ea;
+  --ink-2: #b9b4a8;
+  --ink-3: #7a766c;
+  --accent: #f5a524;          /* warm amber */
+  --accent-2: #ffc36b;
+  --accent-soft: rgba(245, 165, 36, 0.12);
+  --term: #6ee787;            /* terminal green */
+  --term-soft: rgba(110, 231, 135, 0.12);
+  --danger: #ff6b6b;
+  --violet: #b59cff;
+
+  --font-sans: "Inter Tight", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-display: "Fraunces", "Inter Tight", Georgia, serif;
+  --font-mono: "JetBrains Mono", "SF Mono", "Fira Code", "Cascadia Code", ui-monospace, monospace;
+
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 22px;
+
+  --pad-x: clamp(20px, 4vw, 56px);
+}
+
+/* Theme: terminal green on black */
+[data-theme="terminal"] {
+  --bg: #050606;
+  --bg-1: #0b0d0c;
+  --bg-2: #11140f;
+  --bg-3: #181c14;
+  --ink: #e8efe2;
+  --ink-2: #9cb09a;
+  --ink-3: #5e7060;
+  --accent: #6ee787;
+  --accent-2: #a3f5b4;
+  --accent-soft: rgba(110, 231, 135, 0.12);
+  --term: #6ee787;
+}
+
+/* Theme: paper (light, warm) */
+[data-theme="paper"] {
+  --bg: #f4efe6;
+  --bg-1: #ebe5d8;
+  --bg-2: #e2dac9;
+  --bg-3: #d4cab6;
+  --line: rgba(0, 0, 0, 0.10);
+  --line-2: rgba(0, 0, 0, 0.18);
+  --ink: #1a1814;
+  --ink-2: #4a4639;
+  --ink-3: #807a68;
+  --accent: #c4541a;
+  --accent-2: #e0712f;
+  --accent-soft: rgba(196, 84, 26, 0.10);
+  --term: #2e7d3a;
+}
+
+/* Theme: cool blue OSS-classic */
+[data-theme="cobalt"] {
+  --bg: #07090f;
+  --bg-1: #0d1119;
+  --bg-2: #131826;
+  --bg-3: #1b2236;
+  --ink: #eaf0fa;
+  --ink-2: #a9b6cc;
+  --ink-3: #6e7a91;
+  --accent: #6ea8ff;
+  --accent-2: #9cc1ff;
+  --accent-soft: rgba(110, 168, 255, 0.12);
+}
+
+/* ---- Reset ---- */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-feature-settings: "ss01", "cv11";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  line-height: 1.5;
+  overflow-x: hidden;
+}
+img, svg { display: block; max-width: 100%; }
+button { font: inherit; color: inherit; background: none; border: 0; cursor: pointer; }
+a { color: inherit; text-decoration: none; }
+hr { border: 0; border-top: 1px solid var(--line); margin: 0; }
+
+/* ---- Layout ---- */
+.shell { width: 100%; max-width: 1280px; margin: 0 auto; padding-left: var(--pad-x); padding-right: var(--pad-x); }
+.row { display: flex; align-items: center; }
+.col { display: flex; flex-direction: column; }
+.gap-1 { gap: 4px; }  .gap-2 { gap: 8px; } .gap-3 { gap: 12px; } .gap-4 { gap: 16px; } .gap-6 { gap: 24px; } .gap-8 { gap: 32px; }
+.mono { font-family: var(--font-mono); font-feature-settings: "ss02"; }
+.muted { color: var(--ink-2); }
+.dim { color: var(--ink-3); }
+
+/* ---- Type ---- */
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.eyebrow .dot {
+  display: inline-block;
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent);
+  margin-right: 8px; vertical-align: middle;
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
+h1, h2, h3, h4 { font-family: var(--font-display); font-weight: 500; letter-spacing: -0.02em; line-height: 1.05; margin: 0; }
+.display {
+  font-size: clamp(54px, 8vw, 124px);
+  font-weight: 400;
+  letter-spacing: -0.035em;
+  line-height: 0.96;
+}
+.display em { font-style: italic; font-weight: 300; color: var(--accent); }
+h2.section-h { font-size: clamp(34px, 4.4vw, 60px); letter-spacing: -0.025em; }
+h2.section-h em { font-style: italic; color: var(--accent); font-weight: 400; }
+
+/* ---- Buttons ---- */
+.btn {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 12px 18px; border-radius: 999px;
+  font-size: 14px; font-weight: 500; letter-spacing: -0.01em;
+  border: 1px solid transparent;
+  transition: transform 0.12s ease, background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+  white-space: nowrap;
+}
+.btn:active { transform: translateY(1px); }
+.btn-primary { background: var(--accent); color: #1a1306; border-color: var(--accent); }
+.btn-primary:hover { background: var(--accent-2); }
+.btn-ghost { color: var(--ink); border-color: var(--line-2); }
+.btn-ghost:hover { border-color: var(--ink-2); background: var(--bg-1); }
+.btn-link { color: var(--ink-2); padding: 8px 0; gap: 6px; }
+.btn-link:hover { color: var(--ink); }
+.btn .arr { transition: transform 0.18s ease; }
+.btn:hover .arr { transform: translateX(3px); }
+
+/* ---- Pill / chip ---- */
+.pill {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 5px 12px; border-radius: 999px;
+  border: 1px solid var(--line-2);
+  font-family: var(--font-mono); font-size: 11.5px; letter-spacing: 0.04em;
+  color: var(--ink-2);
+  background: var(--bg-1);
+}
+.pill .live { width: 6px; height: 6px; border-radius: 50%; background: var(--term); box-shadow: 0 0 0 4px var(--term-soft); animation: pulse 2.4s ease-in-out infinite; }
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: .6; transform: scale(0.85); }
+}
+
+/* ---- Nav ---- */
+.nav {
+  position: sticky; top: 0; z-index: 50;
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  backdrop-filter: saturate(160%) blur(14px);
+  -webkit-backdrop-filter: saturate(160%) blur(14px);
+  border-bottom: 1px solid var(--line);
+}
+.nav-inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+.nav-links { display: flex; align-items: center; gap: 22px; }
+.nav-links a { color: var(--ink-2); font-size: 14px; }
+.nav-links a:hover { color: var(--ink); }
+.nav-actions { display: flex; align-items: center; gap: 10px; }
+
+.brandmark { display: flex; align-items: center; gap: 10px; }
+.brand-glyph {
+  width: 28px; height: 28px;
+  display: grid; place-items: center;
+  position: relative;
+}
+.brand-name { font-family: var(--font-display); font-size: 19px; font-weight: 500; letter-spacing: -0.015em; }
+.brand-name .dot-orbit { color: var(--accent); }
+
+/* Lang toggle */
+.lang {
+  display: inline-flex; border: 1px solid var(--line-2); border-radius: 999px;
+  padding: 3px; font-family: var(--font-mono); font-size: 11px;
+}
+.lang button { padding: 4px 10px; border-radius: 999px; color: var(--ink-3); letter-spacing: 0.05em; }
+.lang button[aria-pressed="true"] { background: var(--ink); color: var(--bg); }
+
+/* ---- Hero ---- */
+.hero { position: relative; padding-top: clamp(60px, 8vw, 110px); padding-bottom: clamp(60px, 8vw, 110px); overflow: hidden; }
+.hero-grid {
+  display: grid; grid-template-columns: 1.1fr 1fr; gap: clamp(36px, 5vw, 80px);
+  align-items: end;
+}
+.hero-meta { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 28px; }
+.hero h1 { margin-bottom: 28px; }
+.hero-sub {
+  font-size: clamp(16px, 1.4vw, 19px);
+  color: var(--ink-2);
+  max-width: 52ch;
+  margin-bottom: 36px;
+  text-wrap: pretty;
+}
+.hero-cta { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+
+/* Install bar */
+.install {
+  display: flex; align-items: center; gap: 12px;
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  border-radius: 12px;
+  padding: 6px 6px 6px 14px;
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  color: var(--ink);
+  max-width: 100%;
+}
+.install .prompt { color: var(--accent); user-select: none; }
+.install .cmd { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.install button.copy {
+  font-family: var(--font-mono);
+  font-size: 11.5px; letter-spacing: 0.06em;
+  padding: 8px 12px; border-radius: 8px;
+  background: var(--bg-3); color: var(--ink-2);
+  border: 1px solid var(--line);
+}
+.install button.copy:hover { color: var(--ink); border-color: var(--line-2); }
+.install button.copy.copied { color: var(--term); border-color: var(--term); }
+
+/* Hero stats strip */
+.hero-strip {
+  margin-top: 64px;
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+.hero-strip > div {
+  padding: 22px 24px;
+  border-right: 1px solid var(--line);
+}
+.hero-strip > div:last-child { border-right: 0; }
+.hero-strip .num {
+  font-family: var(--font-display);
+  font-size: clamp(32px, 3.6vw, 48px);
+  font-weight: 400; letter-spacing: -0.02em;
+}
+.hero-strip .num .accent { color: var(--accent); }
+.hero-strip .lbl {
+  font-family: var(--font-mono); font-size: 11px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--ink-3); margin-top: 6px;
+}
+
+/* Hero atmosphere */
+.hero::before {
+  content: "";
+  position: absolute; inset: -60% -20% auto auto;
+  width: 80vw; height: 80vw;
+  background: radial-gradient(circle, var(--accent-soft) 0%, transparent 55%);
+  pointer-events: none;
+  filter: blur(20px);
+}
+
+/* ---- Terminal ---- */
+.terminal {
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 30px 60px -30px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.02) inset;
+  font-family: var(--font-mono); font-size: 13px; line-height: 1.7;
+}
+.terminal-bar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 14px;
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--line);
+}
+.terminal-bar .dots { display: flex; gap: 6px; }
+.terminal-bar .dots span { width: 11px; height: 11px; border-radius: 50%; background: var(--bg-3); }
+.terminal-bar .dots span:nth-child(1) { background: #ff5f57; }
+.terminal-bar .dots span:nth-child(2) { background: #febc2e; }
+.terminal-bar .dots span:nth-child(3) { background: #28c840; }
+.terminal-bar .title { flex: 1; text-align: center; color: var(--ink-3); font-size: 11.5px; letter-spacing: 0.05em; }
+.terminal-body { padding: 18px 22px; min-height: 380px; }
+.terminal-body .line { display: block; min-height: 1.7em; }
+.terminal-body .prompt { color: var(--accent); }
+.terminal-body .at-agent { color: var(--violet); }
+.terminal-body .ok { color: var(--term); }
+.terminal-body .comment { color: var(--ink-3); }
+.terminal-body .arrow { color: var(--ink-3); }
+.terminal-body .keyw { color: var(--accent-2); }
+.terminal-body .caret {
+  display: inline-block; width: 8px; height: 16px;
+  background: var(--ink); vertical-align: -3px;
+  animation: blink 1s steps(2) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+/* ---- Generic section ---- */
+section { padding: clamp(80px, 9vw, 130px) 0; }
+.section-head { margin-bottom: clamp(36px, 4vw, 64px); display: flex; flex-direction: column; gap: 16px; max-width: 880px; }
+.section-head .lede { font-size: clamp(16px, 1.3vw, 18px); color: var(--ink-2); max-width: 56ch; text-wrap: pretty; }
+
+.section-divider { border-top: 1px solid var(--line); }
+
+/* ---- Channels ---- */
+.channels-row {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--bg-1);
+}
+.channel-cell {
+  padding: 28px 24px;
+  border-right: 1px solid var(--line);
+  display: flex; flex-direction: column; gap: 14px;
+  min-height: 180px;
+  transition: background 0.2s;
+}
+.channel-cell:last-child { border-right: 0; }
+.channel-cell:hover { background: var(--bg-2); }
+.channel-cell .ico { width: 28px; height: 28px; color: var(--accent); }
+.channel-cell .name { font-family: var(--font-display); font-size: 22px; letter-spacing: -0.02em; }
+.channel-cell .desc { color: var(--ink-2); font-size: 13.5px; }
+.channel-cell code { font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-3); margin-top: auto; }
+
+/* ---- Agents ---- */
+.agents-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+.agent-card {
+  position: relative;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 18px 18px 16px;
+  background: var(--bg-1);
+  transition: border-color 0.18s, transform 0.18s;
+  display: flex; flex-direction: column; gap: 8px;
+  min-height: 132px;
+}
+.agent-card:hover { border-color: var(--line-2); transform: translateY(-2px); }
+.agent-card.tier-1 { box-shadow: inset 3px 0 0 var(--accent); }
+.agent-card.tier-2 { box-shadow: inset 3px 0 0 var(--violet); }
+.agent-card.tier-3 { box-shadow: inset 3px 0 0 var(--ink-3); }
+.agent-card .at { font-family: var(--font-mono); font-size: 14px; color: var(--ink); }
+.agent-card .at::before { content: "@"; color: var(--accent); }
+.agent-card .role { font-size: 11.5px; color: var(--ink-3); font-family: var(--font-mono); letter-spacing: 0.05em; text-transform: uppercase; }
+.agent-card .use { font-size: 13px; color: var(--ink-2); margin-top: auto; }
+.agent-card .tier {
+  position: absolute; top: 14px; right: 14px;
+  font-family: var(--font-mono); font-size: 10px;
+  color: var(--ink-3); letter-spacing: 0.05em;
+}
+.agents-legend { display: flex; flex-wrap: wrap; gap: 18px; margin-bottom: 28px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-2); }
+.agents-legend span { display: inline-flex; align-items: center; gap: 8px; }
+.agents-legend i { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+.agents-legend .l1 { background: var(--accent); }
+.agents-legend .l2 { background: var(--violet); }
+.agents-legend .l3 { background: var(--ink-3); }
+
+/* ---- Architecture ---- */
+.arch-wrap {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--bg-1);
+  overflow: hidden;
+}
+.arch-svg-wrap { padding: 36px clamp(20px, 3vw, 48px); position: relative; }
+.arch-legend {
+  border-top: 1px solid var(--line);
+  padding: 16px clamp(20px, 3vw, 36px);
+  display: flex; flex-wrap: wrap; gap: 24px;
+  font-family: var(--font-mono); font-size: 12px; color: var(--ink-2);
+  background: var(--bg-2);
+}
+.arch-legend strong { color: var(--ink); font-weight: 500; }
+
+/* ---- Multi-model ---- */
+.mm-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 32px; align-items: stretch;
+}
+.mm-card {
+  background: var(--bg-1); border: 1px solid var(--line);
+  border-radius: var(--radius-lg); padding: 28px;
+  display: flex; flex-direction: column; gap: 18px;
+}
+.mm-card h3 { font-size: 26px; }
+.mm-card .label { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; color: var(--ink-3); text-transform: uppercase; }
+.mm-providers { display: flex; flex-wrap: wrap; gap: 8px; }
+.mm-prov {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 14px; border-radius: 999px;
+  border: 1px solid var(--line-2);
+  font-family: var(--font-mono); font-size: 12px;
+  background: var(--bg-2);
+}
+.mm-prov i { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); }
+.mm-prov.alt i { background: var(--violet); }
+.mm-prov.alt2 i { background: var(--term); }
+.mm-row { display: flex; align-items: center; gap: 12px; padding: 10px 0; border-top: 1px dashed var(--line); }
+.mm-row:first-of-type { border-top: 0; }
+.mm-row .who { font-family: var(--font-mono); font-size: 12.5px; color: var(--ink); width: 100px; flex-shrink: 0; }
+.mm-row .what { font-size: 13.5px; color: var(--ink-2); flex: 1; }
+.mm-row .ms { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); }
+
+/* ---- Before/After ---- */
+.ba-wrap {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+  border: 1px solid var(--line); border-radius: var(--radius-lg); overflow: hidden;
+}
+.ba-side { padding: clamp(28px, 3vw, 44px); display: flex; flex-direction: column; gap: 16px; min-height: 360px; }
+.ba-before { background: var(--bg-1); border-right: 1px solid var(--line); }
+.ba-after { background: linear-gradient(135deg, var(--bg-1), color-mix(in srgb, var(--accent-soft) 70%, var(--bg-1))); position: relative; }
+.ba-side .clock { font-family: var(--font-display); font-size: clamp(48px, 6vw, 88px); letter-spacing: -0.03em; line-height: 1; }
+.ba-after .clock { color: var(--accent); }
+.ba-side .clock .unit { font-family: var(--font-mono); font-size: 0.28em; color: var(--ink-3); letter-spacing: 0.1em; vertical-align: 0.6em; margin-left: 4px; }
+.ba-side ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
+.ba-side li { display: flex; gap: 10px; align-items: flex-start; font-size: 14px; color: var(--ink-2); }
+.ba-side li .mark { font-family: var(--font-mono); color: var(--ink-3); width: 16px; flex-shrink: 0; }
+.ba-after li .mark { color: var(--accent); }
+
+/* ---- SDLC ---- */
+.sdlc-grid { display: grid; grid-template-columns: 1.1fr 1fr; gap: 48px; align-items: start; }
+.pillars { display: flex; flex-wrap: wrap; gap: 8px; }
+.pillars .p {
+  padding: 9px 14px; border-radius: 999px;
+  border: 1px dashed var(--line-2);
+  font-family: var(--font-mono); font-size: 12px; color: var(--ink-2);
+  background: var(--bg-1);
+}
+.pillars .p strong { color: var(--accent); font-weight: 500; }
+.gates {
+  border: 1px solid var(--line); border-radius: var(--radius-lg);
+  background: var(--bg-1); padding: 24px;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.gates h4 { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-3); margin: 0; font-weight: 500; }
+.gate-row { display: flex; align-items: center; gap: 14px; padding: 12px 0; border-top: 1px dashed var(--line); }
+.gate-row:first-of-type { border-top: 0; }
+.gate-row .gid {
+  width: 38px; height: 38px; border-radius: 8px;
+  display: grid; place-items: center;
+  font-family: var(--font-mono); font-size: 13px;
+  background: var(--bg-3); color: var(--accent); border: 1px solid var(--line);
+  flex-shrink: 0;
+}
+.gate-row .gname { font-size: 14px; color: var(--ink); }
+.gate-row .gdesc { font-size: 12.5px; color: var(--ink-3); }
+
+/* ---- Quickstart ---- */
+.qs-tabs { display: flex; gap: 4px; padding: 4px; background: var(--bg-1); border: 1px solid var(--line); border-radius: 10px; width: fit-content; margin-bottom: 20px; }
+.qs-tabs button {
+  padding: 8px 16px; border-radius: 7px;
+  font-family: var(--font-mono); font-size: 12px;
+  color: var(--ink-3); letter-spacing: 0.04em;
+}
+.qs-tabs button[aria-selected="true"] { background: var(--bg-3); color: var(--ink); }
+.qs-block {
+  background: var(--bg-1); border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  padding: 24px 28px;
+  font-family: var(--font-mono); font-size: 13.5px; line-height: 1.85;
+  overflow-x: auto;
+}
+.qs-block .c { color: var(--ink-3); }
+.qs-block .p { color: var(--accent); }
+.qs-block .o { color: var(--term); }
+.qs-block .k { color: var(--accent-2); }
+
+/* ---- Roadmap / Sprint ---- */
+.sprint-wrap { display: grid; grid-template-columns: 1.1fr 1fr; gap: 36px; }
+.sprint-card {
+  border: 1px solid var(--line); border-radius: var(--radius-lg);
+  padding: 28px; background: var(--bg-1);
+  display: flex; flex-direction: column; gap: 14px;
+}
+.sprint-card .hd { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.sprint-card .num {
+  font-family: var(--font-display); font-size: 56px; letter-spacing: -0.03em; line-height: 1;
+}
+.sprint-card .num em { color: var(--accent); font-style: normal; }
+.sprint-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; }
+.sprint-list li {
+  display: flex; gap: 14px; padding: 12px 0;
+  border-top: 1px dashed var(--line);
+  font-size: 13.5px; color: var(--ink-2);
+}
+.sprint-list li:first-child { border-top: 0; }
+.sprint-list li .tag { font-family: var(--font-mono); font-size: 10.5px; color: var(--accent); width: 54px; flex-shrink: 0; padding-top: 1px; letter-spacing: 0.04em; }
+.sprint-list li strong { color: var(--ink); font-weight: 500; }
+
+.timeline { display: flex; flex-direction: column; gap: 0; }
+.timeline-item {
+  display: grid; grid-template-columns: 80px 1fr; gap: 18px;
+  padding: 16px 0; border-top: 1px solid var(--line);
+}
+.timeline-item:first-child { border-top: 0; }
+.timeline-item .ver { font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-3); padding-top: 3px; letter-spacing: 0.04em; }
+.timeline-item h4 { font-family: var(--font-sans); font-size: 15px; font-weight: 500; letter-spacing: -0.005em; color: var(--ink); margin: 0 0 4px; }
+.timeline-item p { margin: 0; font-size: 13px; color: var(--ink-2); }
+.timeline-item.now h4::after { content: "now"; font-family: var(--font-mono); font-size: 9px; padding: 2px 6px; border-radius: 999px; background: var(--accent); color: #1a1306; margin-left: 8px; vertical-align: 1px; letter-spacing: 0.05em; }
+
+/* ---- OSS / Contributing ---- */
+.oss-wrap {
+  position: relative;
+  border: 1px solid var(--line); border-radius: var(--radius-xl);
+  padding: clamp(36px, 5vw, 64px);
+  background:
+    radial-gradient(circle at 80% 20%, var(--accent-soft) 0%, transparent 50%),
+    var(--bg-1);
+  overflow: hidden;
+}
+.oss-wrap h2 { max-width: 18ch; }
+.oss-meta { display: flex; gap: 28px; flex-wrap: wrap; margin-top: 8px; font-family: var(--font-mono); font-size: 12.5px; color: var(--ink-2); }
+.oss-meta span { display: inline-flex; align-items: center; gap: 8px; }
+.oss-meta strong { color: var(--ink); font-weight: 500; }
+
+.oss-cta { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 32px; }
+
+.contrib-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 40px; }
+.contrib-card {
+  background: var(--bg-2); border: 1px solid var(--line);
+  padding: 22px; border-radius: var(--radius-md);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.contrib-card .num { font-family: var(--font-mono); font-size: 11px; color: var(--accent); letter-spacing: 0.1em; }
+.contrib-card h4 { font-family: var(--font-sans); font-size: 16px; font-weight: 500; margin: 0; color: var(--ink); }
+.contrib-card p { font-size: 13px; color: var(--ink-2); margin: 0; }
+
+/* ---- FAQ ---- */
+.faq-wrap { display: flex; flex-direction: column; }
+.faq-item {
+  border-top: 1px solid var(--line);
+  padding: 4px 0;
+}
+.faq-item:last-child { border-bottom: 1px solid var(--line); }
+.faq-q {
+  width: 100%; text-align: left;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 22px 4px; gap: 24px;
+  font-family: var(--font-display); font-size: clamp(18px, 1.7vw, 22px); letter-spacing: -0.015em;
+  color: var(--ink); cursor: pointer;
+}
+.faq-q .marker { font-family: var(--font-mono); font-size: 18px; color: var(--accent); transition: transform 0.2s ease; }
+.faq-item[data-open="true"] .marker { transform: rotate(45deg); }
+.faq-a {
+  max-height: 0; overflow: hidden;
+  transition: max-height 0.3s ease;
+  color: var(--ink-2);
+  font-size: 14.5px; line-height: 1.65;
+  padding: 0 4px;
+}
+.faq-item[data-open="true"] .faq-a { max-height: 400px; padding-bottom: 22px; }
+
+/* ---- Footer ---- */
+footer.foot { padding: 80px 0 48px; border-top: 1px solid var(--line); }
+.foot-grid { display: grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap: 36px; margin-bottom: 48px; }
+.foot-col h5 { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); margin: 0 0 16px; font-weight: 500; }
+.foot-col ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
+.foot-col a { font-size: 13.5px; color: var(--ink-2); }
+.foot-col a:hover { color: var(--ink); }
+.foot-tag { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); margin-top: 16px; max-width: 36ch; }
+.foot-bottom {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-top: 28px; border-top: 1px solid var(--line);
+  font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); letter-spacing: 0.04em;
+}
+
+/* ---- Density / compact mode ---- */
+[data-density="compact"] section { padding: clamp(56px, 6vw, 88px) 0; }
+[data-density="compact"] .hero { padding-top: clamp(40px, 5vw, 80px); padding-bottom: clamp(40px, 5vw, 80px); }
+[data-density="compact"] .display { font-size: clamp(44px, 6.5vw, 96px); }
+
+/* ---- Responsive ---- */
+@media (max-width: 1080px) {
+  .hero-grid { grid-template-columns: 1fr; }
+  .hero-strip { grid-template-columns: repeat(5, 1fr); }
+  .channels-row { grid-template-columns: repeat(5, minmax(160px, 1fr)); overflow-x: auto; }
+  .agents-grid { grid-template-columns: repeat(3, 1fr); }
+  .mm-grid, .sdlc-grid, .sprint-wrap { grid-template-columns: 1fr; }
+  .ba-wrap { grid-template-columns: 1fr; }
+  .ba-before { border-right: 0; border-bottom: 1px solid var(--line); }
+  .foot-grid { grid-template-columns: 1fr 1fr; }
+  .contrib-grid { grid-template-columns: 1fr; }
+}
+@media (max-width: 720px) {
+  .nav-links { display: none; }
+  .hero-strip { grid-template-columns: repeat(2, 1fr); }
+  .hero-strip > div { border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+  .agents-grid { grid-template-columns: repeat(2, 1fr); }
+  .channels-row { grid-template-columns: repeat(5, minmax(140px, 1fr)); }
+  .foot-grid { grid-template-columns: 1fr; }
+}

--- a/site/tweaks-panel.jsx
+++ b/site/tweaks-panel.jsx
@@ -1,0 +1,425 @@
+
+// tweaks-panel.jsx
+// Reusable Tweaks shell + form-control helpers.
+//
+// Owns the host protocol (listens for __activate_edit_mode / __deactivate_edit_mode,
+// posts __edit_mode_available / __edit_mode_set_keys / __edit_mode_dismissed) so
+// individual prototypes don't re-roll it. Ships a consistent set of controls so you
+// don't hand-draw <input type="range">, segmented radios, steppers, etc.
+//
+// Usage (in an HTML file that loads React + Babel):
+//
+//   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+//     "primaryColor": "#D97757",
+//     "fontSize": 16,
+//     "density": "regular",
+//     "dark": false
+//   }/*EDITMODE-END*/;
+//
+//   function App() {
+//     const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+//     return (
+//       <div style={{ fontSize: t.fontSize, color: t.primaryColor }}>
+//         Hello
+//         <TweaksPanel>
+//           <TweakSection label="Typography" />
+//           <TweakSlider label="Font size" value={t.fontSize} min={10} max={32} unit="px"
+//                        onChange={(v) => setTweak('fontSize', v)} />
+//           <TweakRadio  label="Density" value={t.density}
+//                        options={['compact', 'regular', 'comfy']}
+//                        onChange={(v) => setTweak('density', v)} />
+//           <TweakSection label="Theme" />
+//           <TweakColor  label="Primary" value={t.primaryColor}
+//                        onChange={(v) => setTweak('primaryColor', v)} />
+//           <TweakToggle label="Dark mode" value={t.dark}
+//                        onChange={(v) => setTweak('dark', v)} />
+//         </TweaksPanel>
+//       </div>
+//     );
+//   }
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+const __TWEAKS_STYLE = `
+  .twk-panel{position:fixed;right:16px;bottom:16px;z-index:2147483646;width:280px;
+    max-height:calc(100vh - 32px);display:flex;flex-direction:column;
+    background:rgba(250,249,247,.78);color:#29261b;
+    -webkit-backdrop-filter:blur(24px) saturate(160%);backdrop-filter:blur(24px) saturate(160%);
+    border:.5px solid rgba(255,255,255,.6);border-radius:14px;
+    box-shadow:0 1px 0 rgba(255,255,255,.5) inset,0 12px 40px rgba(0,0,0,.18);
+    font:11.5px/1.4 ui-sans-serif,system-ui,-apple-system,sans-serif;overflow:hidden}
+  .twk-hd{display:flex;align-items:center;justify-content:space-between;
+    padding:10px 8px 10px 14px;cursor:move;user-select:none}
+  .twk-hd b{font-size:12px;font-weight:600;letter-spacing:.01em}
+  .twk-x{appearance:none;border:0;background:transparent;color:rgba(41,38,27,.55);
+    width:22px;height:22px;border-radius:6px;cursor:default;font-size:13px;line-height:1}
+  .twk-x:hover{background:rgba(0,0,0,.06);color:#29261b}
+  .twk-body{padding:2px 14px 14px;display:flex;flex-direction:column;gap:10px;
+    overflow-y:auto;overflow-x:hidden;min-height:0;
+    scrollbar-width:thin;scrollbar-color:rgba(0,0,0,.15) transparent}
+  .twk-body::-webkit-scrollbar{width:8px}
+  .twk-body::-webkit-scrollbar-track{background:transparent;margin:2px}
+  .twk-body::-webkit-scrollbar-thumb{background:rgba(0,0,0,.15);border-radius:4px;
+    border:2px solid transparent;background-clip:content-box}
+  .twk-body::-webkit-scrollbar-thumb:hover{background:rgba(0,0,0,.25);
+    border:2px solid transparent;background-clip:content-box}
+  .twk-row{display:flex;flex-direction:column;gap:5px}
+  .twk-row-h{flex-direction:row;align-items:center;justify-content:space-between;gap:10px}
+  .twk-lbl{display:flex;justify-content:space-between;align-items:baseline;
+    color:rgba(41,38,27,.72)}
+  .twk-lbl>span:first-child{font-weight:500}
+  .twk-val{color:rgba(41,38,27,.5);font-variant-numeric:tabular-nums}
+
+  .twk-sect{font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;
+    color:rgba(41,38,27,.45);padding:10px 0 0}
+  .twk-sect:first-child{padding-top:0}
+
+  .twk-field{appearance:none;width:100%;height:26px;padding:0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;
+    background:rgba(255,255,255,.6);color:inherit;font:inherit;outline:none}
+  .twk-field:focus{border-color:rgba(0,0,0,.25);background:rgba(255,255,255,.85)}
+  select.twk-field{padding-right:22px;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='rgba(0,0,0,.5)' d='M0 0h10L5 6z'/></svg>");
+    background-repeat:no-repeat;background-position:right 8px center}
+
+  .twk-slider{appearance:none;-webkit-appearance:none;width:100%;height:4px;margin:6px 0;
+    border-radius:999px;background:rgba(0,0,0,.12);outline:none}
+  .twk-slider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;
+    width:14px;height:14px;border-radius:50%;background:#fff;
+    border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+  .twk-slider::-moz-range-thumb{width:14px;height:14px;border-radius:50%;
+    background:#fff;border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+
+  .twk-seg{position:relative;display:flex;padding:2px;border-radius:8px;
+    background:rgba(0,0,0,.06);user-select:none}
+  .twk-seg-thumb{position:absolute;top:2px;bottom:2px;border-radius:6px;
+    background:rgba(255,255,255,.9);box-shadow:0 1px 2px rgba(0,0,0,.12);
+    transition:left .15s cubic-bezier(.3,.7,.4,1),width .15s}
+  .twk-seg.dragging .twk-seg-thumb{transition:none}
+  .twk-seg button{appearance:none;position:relative;z-index:1;flex:1;border:0;
+    background:transparent;color:inherit;font:inherit;font-weight:500;min-height:22px;
+    border-radius:6px;cursor:default;padding:4px 6px;line-height:1.2;
+    overflow-wrap:anywhere}
+
+  .twk-toggle{position:relative;width:32px;height:18px;border:0;border-radius:999px;
+    background:rgba(0,0,0,.15);transition:background .15s;cursor:default;padding:0}
+  .twk-toggle[data-on="1"]{background:#34c759}
+  .twk-toggle i{position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;
+    background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.25);transition:transform .15s}
+  .twk-toggle[data-on="1"] i{transform:translateX(14px)}
+
+  .twk-num{display:flex;align-items:center;height:26px;padding:0 0 0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;background:rgba(255,255,255,.6)}
+  .twk-num-lbl{font-weight:500;color:rgba(41,38,27,.6);cursor:ew-resize;
+    user-select:none;padding-right:8px}
+  .twk-num input{flex:1;min-width:0;height:100%;border:0;background:transparent;
+    font:inherit;font-variant-numeric:tabular-nums;text-align:right;padding:0 8px 0 0;
+    outline:none;color:inherit;-moz-appearance:textfield}
+  .twk-num input::-webkit-inner-spin-button,.twk-num input::-webkit-outer-spin-button{
+    -webkit-appearance:none;margin:0}
+  .twk-num-unit{padding-right:8px;color:rgba(41,38,27,.45)}
+
+  .twk-btn{appearance:none;height:26px;padding:0 12px;border:0;border-radius:7px;
+    background:rgba(0,0,0,.78);color:#fff;font:inherit;font-weight:500;cursor:default}
+  .twk-btn:hover{background:rgba(0,0,0,.88)}
+  .twk-btn.secondary{background:rgba(0,0,0,.06);color:inherit}
+  .twk-btn.secondary:hover{background:rgba(0,0,0,.1)}
+
+  .twk-swatch{appearance:none;-webkit-appearance:none;width:56px;height:22px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:6px;padding:0;cursor:default;
+    background:transparent;flex-shrink:0}
+  .twk-swatch::-webkit-color-swatch-wrapper{padding:0}
+  .twk-swatch::-webkit-color-swatch{border:0;border-radius:5.5px}
+  .twk-swatch::-moz-color-swatch{border:0;border-radius:5.5px}
+`;
+
+// ── useTweaks ───────────────────────────────────────────────────────────────
+// Single source of truth for tweak values. setTweak persists via the host
+// (__edit_mode_set_keys → host rewrites the EDITMODE block on disk).
+function useTweaks(defaults) {
+  const [values, setValues] = React.useState(defaults);
+  // Accepts either setTweak('key', value) or setTweak({ key: value, ... }) so a
+  // useState-style call doesn't write a "[object Object]" key into the persisted
+  // JSON block.
+  const setTweak = React.useCallback((keyOrEdits, val) => {
+    const edits = typeof keyOrEdits === 'object' && keyOrEdits !== null
+      ? keyOrEdits : { [keyOrEdits]: val };
+    setValues((prev) => ({ ...prev, ...edits }));
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits }, '*');
+  }, []);
+  return [values, setTweak];
+}
+
+// ── TweaksPanel ─────────────────────────────────────────────────────────────
+// Floating shell. Registers the protocol listener BEFORE announcing
+// availability — if the announce ran first, the host's activate could land
+// before our handler exists and the toolbar toggle would silently no-op.
+// The close button posts __edit_mode_dismissed so the host's toolbar toggle
+// flips off in lockstep; the host echoes __deactivate_edit_mode back which
+// is what actually hides the panel.
+function TweaksPanel({ title = 'Tweaks', children }) {
+  const [open, setOpen] = React.useState(false);
+  const dragRef = React.useRef(null);
+  const offsetRef = React.useRef({ x: 16, y: 16 });
+  const PAD = 16;
+
+  const clampToViewport = React.useCallback(() => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const w = panel.offsetWidth, h = panel.offsetHeight;
+    const maxRight = Math.max(PAD, window.innerWidth - w - PAD);
+    const maxBottom = Math.max(PAD, window.innerHeight - h - PAD);
+    offsetRef.current = {
+      x: Math.min(maxRight, Math.max(PAD, offsetRef.current.x)),
+      y: Math.min(maxBottom, Math.max(PAD, offsetRef.current.y)),
+    };
+    panel.style.right = offsetRef.current.x + 'px';
+    panel.style.bottom = offsetRef.current.y + 'px';
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+    clampToViewport();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', clampToViewport);
+      return () => window.removeEventListener('resize', clampToViewport);
+    }
+    const ro = new ResizeObserver(clampToViewport);
+    ro.observe(document.documentElement);
+    return () => ro.disconnect();
+  }, [open, clampToViewport]);
+
+  React.useEffect(() => {
+    const onMsg = (e) => {
+      const t = e?.data?.type;
+      if (t === '__activate_edit_mode') setOpen(true);
+      else if (t === '__deactivate_edit_mode') setOpen(false);
+    };
+    window.addEventListener('message', onMsg);
+    window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+    return () => window.removeEventListener('message', onMsg);
+  }, []);
+
+  const dismiss = () => {
+    setOpen(false);
+    window.parent.postMessage({ type: '__edit_mode_dismissed' }, '*');
+  };
+
+  const onDragStart = (e) => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const r = panel.getBoundingClientRect();
+    const sx = e.clientX, sy = e.clientY;
+    const startRight = window.innerWidth - r.right;
+    const startBottom = window.innerHeight - r.bottom;
+    const move = (ev) => {
+      offsetRef.current = {
+        x: startRight - (ev.clientX - sx),
+        y: startBottom - (ev.clientY - sy),
+      };
+      clampToViewport();
+    };
+    const up = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  if (!open) return null;
+  return (
+    <>
+      <style>{__TWEAKS_STYLE}</style>
+      <div ref={dragRef} className="twk-panel"
+           style={{ right: offsetRef.current.x, bottom: offsetRef.current.y }}>
+        <div className="twk-hd" onMouseDown={onDragStart}>
+          <b>{title}</b>
+          <button className="twk-x" aria-label="Close tweaks"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={dismiss}>✕</button>
+        </div>
+        <div className="twk-body">{children}</div>
+      </div>
+    </>
+  );
+}
+
+// ── Layout helpers ──────────────────────────────────────────────────────────
+
+function TweakSection({ label, children }) {
+  return (
+    <>
+      <div className="twk-sect">{label}</div>
+      {children}
+    </>
+  );
+}
+
+function TweakRow({ label, value, children, inline = false }) {
+  return (
+    <div className={inline ? 'twk-row twk-row-h' : 'twk-row'}>
+      <div className="twk-lbl">
+        <span>{label}</span>
+        {value != null && <span className="twk-val">{value}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+
+function TweakSlider({ label, value, min = 0, max = 100, step = 1, unit = '', onChange }) {
+  return (
+    <TweakRow label={label} value={`${value}${unit}`}>
+      <input type="range" className="twk-slider" min={min} max={max} step={step}
+             value={value} onChange={(e) => onChange(Number(e.target.value))} />
+    </TweakRow>
+  );
+}
+
+function TweakToggle({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <button type="button" className="twk-toggle" data-on={value ? '1' : '0'}
+              role="switch" aria-checked={!!value}
+              onClick={() => onChange(!value)}><i /></button>
+    </div>
+  );
+}
+
+function TweakRadio({ label, value, options, onChange }) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+  const opts = options.map((o) => (typeof o === 'object' ? o : { value: o, label: o }));
+  const idx = Math.max(0, opts.findIndex((o) => o.value === value));
+  const n = opts.length;
+
+  // The active value is read by pointer-move handlers attached for the lifetime
+  // of a drag — ref it so a stale closure doesn't fire onChange for every move.
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+
+  const segAt = (clientX) => {
+    const r = trackRef.current.getBoundingClientRect();
+    const inner = r.width - 4;
+    const i = Math.floor(((clientX - r.left - 2) / inner) * n);
+    return opts[Math.max(0, Math.min(n - 1, i))].value;
+  };
+
+  const onPointerDown = (e) => {
+    setDragging(true);
+    const v0 = segAt(e.clientX);
+    if (v0 !== valueRef.current) onChange(v0);
+    const move = (ev) => {
+      if (!trackRef.current) return;
+      const v = segAt(ev.clientX);
+      if (v !== valueRef.current) onChange(v);
+    };
+    const up = () => {
+      setDragging(false);
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  return (
+    <TweakRow label={label}>
+      <div ref={trackRef} role="radiogroup" onPointerDown={onPointerDown}
+           className={dragging ? 'twk-seg dragging' : 'twk-seg'}>
+        <div className="twk-seg-thumb"
+             style={{ left: `calc(2px + ${idx} * (100% - 4px) / ${n})`,
+                      width: `calc((100% - 4px) / ${n})` }} />
+        {opts.map((o) => (
+          <button key={o.value} type="button" role="radio" aria-checked={o.value === value}>
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakSelect({ label, value, options, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <select className="twk-field" value={value} onChange={(e) => onChange(e.target.value)}>
+        {options.map((o) => {
+          const v = typeof o === 'object' ? o.value : o;
+          const l = typeof o === 'object' ? o.label : o;
+          return <option key={v} value={v}>{l}</option>;
+        })}
+      </select>
+    </TweakRow>
+  );
+}
+
+function TweakText({ label, value, placeholder, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <input className="twk-field" type="text" value={value} placeholder={placeholder}
+             onChange={(e) => onChange(e.target.value)} />
+    </TweakRow>
+  );
+}
+
+function TweakNumber({ label, value, min, max, step = 1, unit = '', onChange }) {
+  const clamp = (n) => {
+    if (min != null && n < min) return min;
+    if (max != null && n > max) return max;
+    return n;
+  };
+  const startRef = React.useRef({ x: 0, val: 0 });
+  const onScrubStart = (e) => {
+    e.preventDefault();
+    startRef.current = { x: e.clientX, val: value };
+    const decimals = (String(step).split('.')[1] || '').length;
+    const move = (ev) => {
+      const dx = ev.clientX - startRef.current.x;
+      const raw = startRef.current.val + dx * step;
+      const snapped = Math.round(raw / step) * step;
+      onChange(clamp(Number(snapped.toFixed(decimals))));
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+  return (
+    <div className="twk-num">
+      <span className="twk-num-lbl" onPointerDown={onScrubStart}>{label}</span>
+      <input type="number" value={value} min={min} max={max} step={step}
+             onChange={(e) => onChange(clamp(Number(e.target.value)))} />
+      {unit && <span className="twk-num-unit">{unit}</span>}
+    </div>
+  );
+}
+
+function TweakColor({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <input type="color" className="twk-swatch" value={value}
+             onChange={(e) => onChange(e.target.value)} />
+    </div>
+  );
+}
+
+function TweakButton({ label, onClick, secondary = false }) {
+  return (
+    <button type="button" className={secondary ? 'twk-btn secondary' : 'twk-btn'}
+            onClick={onClick}>{label}</button>
+  );
+}
+
+Object.assign(window, {
+  useTweaks, TweaksPanel, TweakSection, TweakRow,
+  TweakSlider, TweakToggle, TweakRadio, TweakSelect,
+  TweakText, TweakNumber, TweakColor, TweakButton,
+});


### PR DESCRIPTION
## Summary

- Lands the GitHub Pages source-of-truth content for `sdlcframework.org` per **SDLC-Orchestrator PR #84** (Sprint 67 plan Amendment 2026-04-28b — pivot from Vercel-host to GitHub Pages mirroring EndiorBot pattern).
- 8 landing-page assets copied from SDLC-Orchestrator `landing-pages/sdlc-framework/site/` staging snapshot (2026-04-28 08:06 ICT) into this repo's `/site/` directory.
- 1 new `/site/CNAME` (18 bytes: `sdlcframework.org` + single trailing LF) — byte-for-byte matching the EndiorBot `endior.net` CNAME convention.

## What is NOT included

- ❌ `vercel.json` from staging dir — irrelevant on GitHub Pages (Vercel-specific HSTS/CSP/cache headers don't apply on GH Pages edge). Sprint plan 2026-04-28b explicitly downgrades it to staging-only artifact.

## Cite-back trail

| Artifact | Location |
|---|---|
| Sprint plan Amendment 2026-04-28b (pivot rationale) | [Minh-Tam-Solution/SDLC-Orchestrator#84](https://github.com/Minh-Tam-Solution/SDLC-Orchestrator/pull/84) |
| S67-09 evidence (Vercel DNS reconfigure receipt — AC6a GREEN) | SDLC-Orchestrator `docs/04-build/evidence/sprint-67-s67-09-vercel-dns-reconfigure.md` (commit `0080074`) |
| S67-05 OSS-readiness docs (LICENSE, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT) | [PR #4](https://github.com/Minh-Tam-Solution/SDLC-Enterprise-Framework/pull/4) (already merged) |
| **This PR — S67-06 content + CNAME landing** | (this PR) |
| S67-10 — repo Settings → Pages → branch `main` `/site` | Pending CTO Rule 7 spot-check on this PR per CPO authorization 2026-04-28 |

## CPO constraints honoured (per stamp 2026-04-28)

- ✅ 8 files copied excluding `vercel.json`
- ✅ `/site/CNAME` exact content `sdlcframework.org` (verified via `xxd`: `7364 6c63 6672 616d 6577 6f72 6b2e 6f72 670a` = 17 chars + `0a` LF, no other whitespace, no protocol)
- ✅ PR body cites SDLC-Orchestrator PR #84 for cite-back trail
- ✅ Branched from `origin/main` directly (not from in-flight `chore/framework-reorg-cross-ring-dedup`) per workspace-discipline

## File count clarification (transparency)

SDLC-Orchestrator sprint plan §"Sprint 67 Outcome" originally said `7 copied + 1 new CNAME`. Actual count this PR: **8 copied + 1 CNAME = 9 files** in `/site/`. Discrepancy origin: staging dir gained `vercel.json` after original S67-02 commit (added under Amendment 2026-04-28a Vercel-host framing); under 2026-04-28b pivot we skip `vercel.json` but the underlying landing-asset count was always 8, not 7. Sprint plan count line is outdated by 1 — non-blocking, will fold into S67-08 close cleanup.

## What unblocks after this PR merges

| Gate | Currently | After this merges + S67-10 enables Pages |
|---|---|---|
| AC6 (`server: GitHub.com` 200 with content) | 🔴 404 (no repo claims domain) | ✅ 200 serving `site/index.html` |
| AC6b (HTTPS cert valid, Let's Encrypt) | 🔴 no cert provisioned | ✅ auto-provision 5-15 min after S67-10 (CAA record `letsencrypt.org` already permits) |

## Test plan

- [ ] CTO Rule 7 spot-check ≥3 claims:
  - [ ] `/site/CNAME` content = `sdlcframework.org\n` (18 bytes)
  - [ ] `/site/index.html` present and references the JSX/CSS assets correctly
  - [ ] No `vercel.json` present in `/site/`
- [ ] CPO independent verification: file count + CNAME bytes + cite-back trail present in PR body
- [ ] After merge: trigger S67-10 (repo admin: Settings → Pages → branch `main`, folder `/site` → Save)
- [ ] After S67-10 + 5-15 min: `curl -sI https://sdlcframework.org` returns `HTTP/2 200`, `server: GitHub.com`
- [ ] HTTPS cert issuer = Let's Encrypt

🤖 Generated with [Claude Code](https://claude.com/claude-code)