### PR TITLE
feat(sprint-67): S67-10 — GitHub Pages deploy workflow for /site path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy /site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload /site as Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Enables GitHub Pages deployment from `/site/` folder via custom Actions workflow.

**Why this PR exists**: GitHub Pages REST API restricts `source.path` to `/` (root) or `/docs` only. PR #6 chose `/site/` for the landing page (semantic separation from methodology docs). To honor that path choice without folder rename, use `actions/upload-pages-artifact` workflow.

## What changed

| File | Change |
|------|--------|
| `.github/workflows/pages.yml` | NEW — 39 lines |

## Workflow behavior

- **Trigger**: push to `main` when `site/**` changes (or manual via workflow_dispatch)
- **Steps**:
  1. Checkout
  2. Configure Pages
  3. Upload `site/` folder content as Pages artifact
  4. Deploy via `actions/deploy-pages@v4`
- **Permissions**: minimum scope (contents:read, pages:write, id-token:write for OIDC)
- **Concurrency**: group=pages, prevents overlapping deploys

## Coordination

CEO authorized Path A (pre-flip public + enable Pages NOW) 2026-04-28 ~20:20 ICT vs the original 29/4 morning plan. This workflow lands as the deployment mechanism. After merge, manual `workflow_dispatch` triggers first deploy → Let's Encrypt cert provisions ~5-15 min → https://sdlcframework.org goes live.

## Test plan

- [ ] After merge: trigger via `gh workflow run pages.yml` or push to main
- [ ] Verify run completes green in Actions tab
- [ ] Verify https://sdlcframework.org resolves with valid cert
- [ ] Verify all 8 site assets (CSS + JSX + JS) load (no 404s)
- [ ] Verify CNAME persistence (GH may rewrite CNAME file — check post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)