### PR TITLE
chore(reorg): MCP integration → Case Study (vendor-neutrality fix, CEO Option B)

### DIFF
--- a/04-AI-TOOLS-LANDSCAPE/README.md
+++ b/04-AI-TOOLS-LANDSCAPE/README.md
@@ -50,7 +50,7 @@ To govern effectively, Orchestrator MUST:
 | Tool Profiles ([Claude Code](tool-profiles/claude-code-2026.md) · [Cursor](tool-profiles/cursor-2026.md) · [Copilot](tool-profiles/copilot-2026.md)) | Individual tool capabilities | As needed |
 | [Capability Matrix](capability-matrix.md) | Feature comparison & readiness score | Quarterly |
 | [Best Practices 2026](best-practices-2026/) | AI agent workflows, planning mode, model selection | As needed |
-| [Integration Notes](integration-guides/mcp-integration.md) | MCP onboarding playbook | As needed |
+| [Integration Notes](../06-Case-Studies/MCP-Integration-Case-Study-SDLC-Orchestrator.md) | MCP onboarding playbook | As needed |
 | Trend Watch ([Jan 2026](trend-watch/2026-01-trends.md)) | Emerging patterns and features | Monthly |
 
 ---
@@ -206,10 +206,11 @@ These patterns proved universal and were promoted to [03-AI-GOVERNANCE/](../03-A
 │   ├── 07-permissions-security.md # Safe AI execution
 │   └── 08-developer-role-evolution.md # SE 3.0 responsibilities
 ├── capability-matrix.md         # Detailed comparison
-├── integration-guides/          # Orchestrator integration
-│   └── mcp-integration.md
 └── trend-watch/                 # Monthly updates
     └── 2026-01-trends.md
+
+# Vendor-specific integration case studies live in 06-Case-Studies/
+# (e.g., MCP-Integration-Case-Study-SDLC-Orchestrator.md)
 ```
 
 ---

--- a/04-AI-TOOLS-LANDSCAPE/trend-watch/2026-01-trends.md
+++ b/04-AI-TOOLS-LANDSCAPE/trend-watch/2026-01-trends.md
@@ -52,7 +52,7 @@
 
 ## Recommendations (Q1 2026)
 
-1. **Standardize MCP onboarding** – Roll out `integration-guides/mcp-integration.md` to all Claude Code projects.
+1. **Standardize MCP onboarding** – Roll out `../06-Case-Studies/MCP-Integration-Case-Study-SDLC-Orchestrator.md` to all Claude Code projects.
 2. **Prototype Cursor log sync** – Build lightweight script to push session logs to Evidence Vault.
 3. **Define Copilot governance policy** – Require `copilot-instructions.md` + PR annotations for AI-assisted code.
 4. **Engage AWS** – Join Amazon Q private preview to influence MCP parity.

--- a/06-Case-Studies/MCP-Integration-Case-Study-SDLC-Orchestrator.md
+++ b/06-Case-Studies/MCP-Integration-Case-Study-SDLC-Orchestrator.md
@@ -1,14 +1,16 @@
-# MCP Integration Guide (SDLC Orchestrator)
+# MCP Integration — Case Study (SDLC Orchestrator)
 
-**Version**: 6.3.1  
-**Status**: ACTIVE - OUTER RING  
-**Audience**: Platform / DevOps teams integrating AI tools with SDLC Orchestrator
+**Version**: 6.3.1
+**Status**: ACTIVE — Case Study (vendor-specific implementation example)
+**Audience**: Platform / DevOps teams integrating AI tools with an SDLC governance platform
+
+> **Note on framing**: This document was originally authored as an integration guide inside `04-AI-TOOLS-LANDSCAPE/`. It has been relocated to `06-Case-Studies/` because its content is **specific to the SDLC Orchestrator implementation** of the Framework, not a tool-agnostic integration pattern. Adopters implementing MCP on other platforms should treat this as **one reference example**, not as the Framework's normative guidance. Generic MCP integration tactics live in [`07-Implementation-Guides/MCP-Integration-Guide.md`](../07-Implementation-Guides/MCP-Integration-Guide.md).
 
 ---
 
 ## Purpose
 
-Model Context Protocol (MCP) unlocks deep, governed integration between SDLC Orchestrator and AI development tools. This guide documents the reference architecture, security controls, and validation steps required to onboard MCP-capable tools (e.g., Claude Code) into the enterprise environment.
+Model Context Protocol (MCP) unlocks deep, governed integration between SDLC Orchestrator and AI development tools. This case study documents the reference architecture, security controls, and validation steps required to onboard MCP-capable tools (e.g., Claude Code) into the enterprise environment **as implemented in SDLC Orchestrator**.
 
 ---
 

--- a/CONTENT-MAP.md
+++ b/CONTENT-MAP.md
@@ -236,7 +236,7 @@ Before creating any new document, check if a canonical file already exists for t
 | Cursor Profile | `04-AI-TOOLS-LANDSCAPE/tool-profiles/cursor-2026.md` | Reference profile (IDE-native) | ACTIVE |
 | Copilot Profile | `04-AI-TOOLS-LANDSCAPE/tool-profiles/copilot-2026.md` | Reference profile (inline assist) | ACTIVE |
 | Capability Matrix | `04-AI-TOOLS-LANDSCAPE/capability-matrix.md` | Tool comparison | ACTIVE |
-| MCP Integration Guide | `04-AI-TOOLS-LANDSCAPE/integration-guides/mcp-integration.md` | Protocol onboarding steps | ACTIVE |
+| MCP Integration Guide | `06-Case-Studies/MCP-Integration-Case-Study-SDLC-Orchestrator.md` | Protocol onboarding steps | ACTIVE |
 | Trend Watch | `04-AI-TOOLS-LANDSCAPE/trend-watch/` | Monthly updates (starting with 2026-01-trends.md) | ACTIVE |
 
 > **Note**: This is OUTER RING content but STRATEGIC for Orchestrator.


### PR DESCRIPTION
## Summary

Closes the last cross-ring vendor-neutrality concern surfaced in PR #5 reorg discovery (Batch C). Per CEO directive 2026-04-28 ("MCP duplication theo phương án b nhé"), relocate vendor-specific MCP guide from tool-agnostic section to case-studies.

## Changes

| Change | From | To |
|--------|------|-----|
| `git mv` | `04-AI-TOOLS-LANDSCAPE/integration-guides/mcp-integration.md` | `06-Case-Studies/MCP-Integration-Case-Study-SDLC-Orchestrator.md` |
| `rmdir` | `04-AI-TOOLS-LANDSCAPE/integration-guides/` (now empty) | — |
| Title | "MCP Integration Guide" | "MCP Integration — Case Study" |
| Status | "ACTIVE - OUTER RING" | "ACTIVE — Case Study (vendor-specific implementation example)" |
| Added | Framing note pointing to generic guide at `07-Implementation-Guides/MCP-Integration-Guide.md` |
| Cross-refs | 4 updates (04-AI-Tools README + trend-watch + CONTENT-MAP) |

## Why Option B (move) over A (remove) or C (genericize)

- **(A) Remove**: would lose live evidence of how MCP integrates into a Pillar; adopters lose pattern reference
- **(B) Move** ← chosen: case-studies is the right home for vendor-specific examples; preserves content while honoring vendor-neutrality rule for normative content
- **(C) Genericize**: vendor-neutralization mid-content was risky pre-launch; deferred to potential follow-up sprint after observing adopter feedback

## Vendor-neutrality discipline

Per Framework's tool-agnostic methodology principle, `04-AI-TOOLS-LANDSCAPE/` should contain neutral tool comparisons + best practices. Vendor-specific implementation guides belong in `06-Case-Studies/`.

## Net effect

- 1 file moved (R80, 80% content similarity due to header + framing changes)
- 1 directory removed (now-empty `integration-guides/`)
- 3 active-dir files updated (cross-refs)
- 1 meta-doc updated (CONTENT-MAP.md)
- Zero content loss; zero broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)