### PR TITLE
docs(convention-a): inline β-clarifier on divergent Version markers (3 docs)

### DIFF
--- a/01-Overview/SDLC-Executive-Summary.md
+++ b/01-Overview/SDLC-Executive-Summary.md
@@ -4,7 +4,7 @@ sdlc_framework: "6.3.2"
 
 # SDLC 6.3.2 Executive Summary
 
-**Version**: 6.4.0
+**Version**: 6.4.0 *(doc's own semver — independent of Framework version; see [Schema-Versioning §Convention A](../02-Core-Methodology/SDLC-Schema-Versioning.md#document-version-convention-convention-a--formalized-amendment-b-2026-06-03))*
 **Release Date**: March 18, 2026 (AGENTIC SDLC + LEAN RING 1)
 **Last Updated**: 2026-06-03
 **Status**: ACTIVE

--- a/02-Core-Methodology/Documentation-Standards/SDLC-Project-Structure-Standard.md
+++ b/02-Core-Methodology/Documentation-Standards/SDLC-Project-Structure-Standard.md
@@ -4,7 +4,7 @@ sdlc_framework: "6.3.0"
 
 # SDLC Project Structure Standard
 
-**Version**: 6.3.1
+**Version**: 6.3.1 *(doc's own semver — independent of Framework version; see [Schema-Versioning §Convention A](../SDLC-Schema-Versioning.md#document-version-convention-convention-a--formalized-amendment-b-2026-06-03))*
 **Date**: 2026-06-03
 **Last Updated**: 2026-06-03
 **Status**: ACTIVE

--- a/02-Core-Methodology/SDLC-Schema-Versioning.md
+++ b/02-Core-Methodology/SDLC-Schema-Versioning.md
@@ -1,6 +1,6 @@
 # SDLC Framework Versioning Rules
 
-**Version**: 1.1.0
+**Version**: 1.1.0 *(doc's own semver — independent of Framework version; see [§Document Version Convention](#document-version-convention-convention-a--formalized-amendment-b-2026-06-03) below)*
 **Effective Date**: 2026-01-28
 **Last Updated**: 2026-06-03 (added §"Document Version Convention (Convention A)" per Amendment B + MM#9 — see CHANGELOG v6.3.2)
 **SDLC Framework Version**: 6.3.2


### PR DESCRIPTION
## β Clarifier Application Report

**Pre-audit scope (read-only)**:
- Total .md files scanned: 189
- Docs with both Version + sdlc_framework markers: 4
- Truly divergent (real values, not placeholders): 3

**Decision matrix**:

| File | Version | sdlc_framework | Action | Why |
|---|---|---|---|---|
| 02-Core-Methodology/SDLC-Schema-Versioning.md | 1.1.0 | 6.3.2 | APPLIED β | Canonical Convention A doc; largest visible gap |
| 01-Overview/SDLC-Executive-Summary.md | 6.4.0 | 6.3.2 | APPLIED β | CEO's actual point-of-friction |
| 02-Core-Methodology/Documentation-Standards/SDLC-Project-Structure-Standard.md | 6.3.1 | 6.3.0 | APPLIED β | Visible divergence even though both old |
| 05-Templates-Tools/04-SASE-Artifacts/souls/SOUL-writer.md | {semver} | 6.3.1 | SKIPPED | Template placeholder, not real semver |

**Negative-protection results**:
- Files touched outside audit table: 0
- Template files touched: 0
- 10-Archive files touched: 0
- Version values changed: 0
- sdlc_framework values changed: 0
- Field labels changed: 0

**Diff scope**:
- Files modified: 3
- Lines added: 3
- Lines removed: 3
- Net: 0

**Convention A self-check** (the Framework eats its own dogfood):
- This PR's surface = β clarifier on 3 docs out of 189 total scanned (3/189 = 1.6%)
- Demand: 1 confirmed reader-confusion report (CEO 2026-06-03 at Exec-Summary)
- MM#9 daily-user named? YES — reader trying to grok Framework version status from doc header
- ON-DEMAND label needed? NO — addresses confirmed demand
- 90-day re-eval trigger needed? NO — fix is one-shot, no ongoing surface

---

/cc @cto for 4-gate verification